### PR TITLE
Align .enter to current spec

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -26,6 +26,54 @@ describe('Space (mockClient)', () => {
     });
   });
 
+  describe('enter', () => {
+    it<SpaceTestContext>('enter a space successfully', async ({ client }) => {
+      const spaceName = '_ably_space_test';
+      const space = new Space('test', client);
+
+      const presence = client.channels.get(spaceName).presence;
+      const presenceLeaveSpy = vi.spyOn(presence, 'enter').mockResolvedValueOnce();
+
+      await space.enter();
+      expect(presenceLeaveSpy).toHaveBeenCalledOnce();
+    });
+
+    it<SpaceTestContext>('returns current space members', async ({ client }) => {
+      const spaceName = '_ably_space_test';
+      const space = new Space('test', client);
+
+      const presence = client.channels.get(spaceName).presence;
+
+      vi.spyOn(presence, 'get').mockResolvedValueOnce([
+        {
+          clientId: '1',
+          data: '{ "a": 1 }',
+          action: 'enter',
+          connectionId: '1',
+          id: '1',
+          encoding: 'json',
+          timestamp: 324325323423,
+        },
+        {
+          clientId: '2',
+          data: '{ "a": 2 }',
+          action: 'update',
+          connectionId: '2',
+          id: '2',
+          encoding: 'json',
+          timestamp: 324325323423,
+        },
+      ]);
+
+      const spaceMembers = await space.enter();
+
+      expect(spaceMembers).toEqual([
+        { clientId: '1', isConnected: true, data: { a: 1 } },
+        { clientId: '2', isConnected: true, data: { a: 2 } },
+      ]);
+    });
+  });
+
   describe('leave', () => {
     it<SpaceTestContext>('leaves a space successfully', async ({ client }) => {
       const spaceName = '_ably_space_test';

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -1,13 +1,4 @@
 import { Types } from 'ably';
-import SpaceOptions from './options/SpaceOptions';
-
-const ERROR_CLIENT_ALREADY_ENTERED = 'Client has already entered the space';
-
-class MemberUpdateEvent extends Event {
-  constructor(public members: SpaceMember[]) {
-    super('memberUpdate', {});
-  }
-}
 
 const createSpaceMemberFromPresenceMember = (m: Types.PresenceMessage): SpaceMember => ({
   clientId: m.clientId as string,
@@ -15,100 +6,39 @@ const createSpaceMemberFromPresenceMember = (m: Types.PresenceMessage): SpaceMem
   data: JSON.parse(m.data as string),
 });
 
+// Unique prefix to avoid conflicts with channels
+const SPACE_CHANNEL_PREFIX = '_ably_space_';
+
 class Space extends EventTarget {
-  private members: SpaceMember[] = [];
   private channelName: string;
+  private clientId: string;
   private channel: Types.RealtimeChannelPromise;
 
   eventTarget: EventTarget;
 
-  constructor(private name: string, private client: Types.RealtimePromise, private options?: SpaceOptions) {
+  constructor(private name: string, private client: Types.RealtimePromise) {
     super();
+    this.clientId = this.client.auth.clientId;
     this.setChannel(this.name);
   }
 
   private setChannel(rootName) {
-    // The channel name prefix here should be unique to avoid conflicts with non-space channels
-    this.channelName = `_ably_space_${rootName}`;
+    this.channelName = `${SPACE_CHANNEL_PREFIX}${rootName}`;
     this.channel = this.client.channels.get(this.channelName);
   }
 
-  private createMember(clientId: string, isConnected: boolean, data: { [key: string]: any }) {
-    this.members.push({ clientId, isConnected, data });
-  }
-
-  private syncMembers() {
-    this.channel.presence.get().then((presenceMessages) => {
-      this.members = presenceMessages.filter((m) => m.clientId).map(createSpaceMemberFromPresenceMember);
-    });
-  }
-
-  private subscribeToPresenceEvents() {
-    this.channel.presence.subscribe('enter', (message: Types.PresenceMessage) => {
-      this.updateMemberState(message.clientId, true, JSON.parse(message.data as string));
-    });
-
-    this.channel.presence.subscribe('leave', (message: Types.PresenceMessage) => {
-      this.updateMemberState(message.clientId, false);
-    });
-
-    this.channel.presence.subscribe('update', (message: Types.PresenceMessage) => {
-      this.updateMemberState(message.clientId, true, JSON.parse(message.data as string));
-    });
-  }
-
-  private updateMemberState(clientId: string | undefined, isConnected: boolean, data?: { [key: string]: any }) {
-    const implicitClientId = clientId ?? this.client.auth.clientId;
-
-    if (!implicitClientId) {
-      return;
-    }
-
-    const member = this.members.find((m) => m.clientId === clientId);
-
-    if (!member) {
-      this.createMember(implicitClientId, isConnected, data || {});
-    } else {
-      member.isConnected = isConnected;
-      if (data) {
-        // Member data is completely overridden, except lastEventTimestamp which is updated
-        member.data = {
-          ...data,
-          lastEventTimestamp: new Date(),
-        };
-      }
-    }
-
-    const memberUpdateEvent = new MemberUpdateEvent(this.members);
-    this.dispatchEvent(memberUpdateEvent);
-  }
-
-  enter(data: unknown) {
-    if (!data || typeof data !== 'object') {
-      return;
-    }
-
-    const clientId = this.client.auth.clientId || undefined;
+  async enter(data?: unknown) {
     const presence = this.channel.presence;
+    await presence.enter(data);
+    const presenceMessages = await presence.get();
 
-    // TODO: Discuss if we actually want change this behaviour in contrast to presence (enter becomes an update)
-    return presence.get({ clientId }).then(
-      (presenceMessages) =>
-        new Promise((resolve, reject) => {
-          if (presenceMessages && presenceMessages.length === 1) {
-            reject(new Error(ERROR_CLIENT_ALREADY_ENTERED));
-          }
-
-          this.syncMembers();
-          this.subscribeToPresenceEvents();
-          resolve(presence.enter(JSON.stringify(data)));
-        })
-    );
+    return presenceMessages
+      .filter((message) => message.clientId !== this.clientId)
+      .map(createSpaceMemberFromPresenceMember);
   }
 
   leave(data?: unknown) {
-    const presence = this.channel.presence;
-    return presence.leave(data);
+    return this.channel.presence.leave(data);
   }
 }
 


### PR DESCRIPTION
As we ideated on .enter and subscriptions in space, some code made it in that is not a defined behaviour in the space spec.

This commit aligns it with the spec.