### PR TITLE
FIX: Remove eventTarget: EventTarget as a public member of Space class

### DIFF
--- a/src/Space.ts
+++ b/src/Space.ts
@@ -20,8 +20,6 @@ class Space extends EventTarget {
   private channelName: string;
   private channel: Types.RealtimeChannelPromise;
 
-  eventTarget: EventTarget;
-
   constructor(private name: string, private client: Types.RealtimePromise, private options?: SpaceOptions) {
     super();
     this.setChannel(this.name);


### PR DESCRIPTION
As Space now extends EventTarget, there is no need to have an eventTarget field on the instantiated object.