### PR TITLE
Add .on method

### DIFF
--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -9,6 +9,7 @@ const mockPresence = {
   get: () => mockPromisify<Types.PresenceMessage[]>([]),
   enter: methodReturningVoidPromise,
   leave: methodReturningVoidPromise,
+  subscribe: () => {},
 };
 
 const mockChannel = {

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -1,17 +1,25 @@
-import { it, describe, expect, vi, beforeEach, expectTypeOf } from 'vitest';
+import { it, describe, expect, vi, beforeEach, expectTypeOf, afterEach } from 'vitest';
 import Ably, { Types } from 'ably/promises';
 
 import Space from './Space';
+import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
+  space: Space;
+  presence: Types.RealtimePresencePromise;
 }
 
 vi.mock('ably/promises');
 
 describe('Space (mockClient)', () => {
   beforeEach<SpaceTestContext>((context) => {
-    context.client = new Ably.Realtime({});
+    const client = new Ably.Realtime({});
+    const presence = client.channels.get('').presence;
+
+    context.client = client;
+    context.space = new Space('test', client);
+    context.presence = presence;
   });
 
   describe('get', () => {
@@ -27,63 +35,230 @@ describe('Space (mockClient)', () => {
   });
 
   describe('enter', () => {
-    it<SpaceTestContext>('enter a space successfully', async ({ client }) => {
-      const spaceName = '_ably_space_test';
-      const space = new Space('test', client);
-
-      const presence = client.channels.get(spaceName).presence;
-      const presenceLeaveSpy = vi.spyOn(presence, 'enter').mockResolvedValueOnce();
-
-      await space.enter();
-      expect(presenceLeaveSpy).toHaveBeenCalledOnce();
+    it<SpaceTestContext>('enter a space successfully', async ({ presence, space }) => {
+      const spy = vi.spyOn(presence, 'enter').mockResolvedValueOnce();
+      await space.enter({ a: 1 });
+      expect(spy).toHaveBeenNthCalledWith(1, { a: 1 });
     });
 
-    it<SpaceTestContext>('returns current space members', async ({ client }) => {
-      const spaceName = '_ably_space_test';
-      const space = new Space('test', client);
-
-      const presence = client.channels.get(spaceName).presence;
-
-      vi.spyOn(presence, 'get').mockResolvedValueOnce([
-        {
-          clientId: '1',
-          data: '{ "a": 1 }',
-          action: 'enter',
-          connectionId: '1',
-          id: '1',
-          encoding: 'json',
-          timestamp: 324325323423,
-        },
-        {
-          clientId: '2',
-          data: '{ "a": 2 }',
-          action: 'update',
-          connectionId: '2',
-          id: '2',
-          encoding: 'json',
-          timestamp: 324325323423,
-        },
+    it<SpaceTestContext>('returns current space members', async ({ presence, space }) => {
+      vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
+        createPresenceMessage('enter'),
+        createPresenceMessage('update', { clientId: '2' }),
       ]);
-
       const spaceMembers = await space.enter();
-
       expect(spaceMembers).toEqual([
-        { clientId: '1', isConnected: true, data: { a: 1 } },
-        { clientId: '2', isConnected: true, data: { a: 2 } },
+        { clientId: '1', isConnected: true, data: {} },
+        { clientId: '2', isConnected: true, data: { a: 1 } },
       ]);
     });
   });
 
   describe('leave', () => {
-    it<SpaceTestContext>('leaves a space successfully', async ({ client }) => {
-      const spaceName = '_ably_space_test';
-      const space = new Space('test', client);
-
-      const presence = client.channels.get(spaceName).presence;
-      const presenceLeaveSpy = vi.spyOn(presence, 'leave');
-
+    it<SpaceTestContext>('leaves a space successfully', async ({ presence, space }) => {
+      const spy = vi.spyOn(presence, 'leave');
       await space.leave();
-      expect(presenceLeaveSpy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('on', () => {
+    it<SpaceTestContext>('subscribes to presence updates', async ({ presence, space }) => {
+      const spy = vi.spyOn(presence, 'subscribe');
+      space.on('membersUpdate', () => {});
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it<SpaceTestContext>('errors if an unrecognized event is passed in', async ({ space }) => {
+      await space.enter();
+      // @ts-expect-error
+      expect(() => space.on('invalidEvent', () => {})).toThrowError('Event "invalidEvent" is unsupported');
+    });
+
+    it<SpaceTestContext>('subscribes to presence events', async ({ presence, space }) => {
+      const spy = vi.spyOn(presence, 'subscribe');
+      space.on('membersUpdate', vi.fn());
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {
+      const spy = vi.fn();
+      space.dispatchEvent(createPresenceEvent('enter', { clientId: client.auth.clientId }));
+      space.on('membersUpdate', spy);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it<SpaceTestContext>('adds new members', async ({ space }) => {
+      const callbackSpy = vi.fn();
+      space.on('membersUpdate', callbackSpy);
+
+      space.dispatchEvent(createPresenceEvent('enter'));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: {},
+          isConnected: true,
+        },
+      ]);
+
+      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: '{ "a": 1 }' }));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: {},
+          isConnected: true,
+        },
+        {
+          clientId: '2',
+          data: { a: 1 },
+          isConnected: true,
+        },
+      ]);
+    });
+
+    it<SpaceTestContext>('updates the data of members', async ({ space }) => {
+      const callbackSpy = vi.fn();
+      space.on('membersUpdate', callbackSpy);
+
+      space.dispatchEvent(createPresenceEvent('enter'));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: {},
+          isConnected: true,
+        },
+      ]);
+
+      space.dispatchEvent(createPresenceEvent('update', { data: '{ "a": 1 }' }));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: { a: 1 },
+          isConnected: true,
+        },
+      ]);
+    });
+
+    it<SpaceTestContext>('updates the connected status of clients who have left', async ({ space }) => {
+      const callbackSpy = vi.fn();
+      space.on('membersUpdate', callbackSpy);
+
+      space.dispatchEvent(createPresenceEvent('enter'));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: {},
+          isConnected: true,
+        },
+      ]);
+
+      space.dispatchEvent(createPresenceEvent('leave'));
+      expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+        {
+          clientId: '1',
+          data: {},
+          isConnected: false,
+        },
+      ]);
+    });
+
+    describe('leavers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it<SpaceTestContext>('removes a member who has left after the offlineTimeout', async ({ space }) => {
+        const callbackSpy = vi.fn();
+        space.on('membersUpdate', callbackSpy);
+
+        space.dispatchEvent(createPresenceEvent('enter'));
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: true,
+          },
+        ]);
+
+        space.dispatchEvent(createPresenceEvent('leave'));
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: false,
+          },
+        ]);
+
+        vi.advanceTimersByTime(130_000);
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, []);
+      });
+
+      it<SpaceTestContext>('does not remove a member that has rejoined', async ({ space }) => {
+        const callbackSpy = vi.fn();
+        space.on('membersUpdate', callbackSpy);
+
+        space.dispatchEvent(createPresenceEvent('enter'));
+        space.dispatchEvent(createPresenceEvent('enter', { clientId: '2' }));
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: true,
+          },
+          {
+            clientId: '2',
+            data: {},
+            isConnected: true,
+          },
+        ]);
+
+        space.dispatchEvent(createPresenceEvent('leave'));
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: false,
+          },
+          {
+            clientId: '2',
+            data: {},
+            isConnected: true,
+          },
+        ]);
+
+        vi.advanceTimersByTime(60_000);
+        space.dispatchEvent(createPresenceEvent('enter'));
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: true,
+          },
+          {
+            clientId: '2',
+            data: {},
+            isConnected: true,
+          },
+        ]);
+
+        vi.advanceTimersByTime(70_000); // 2:10 passed, defaut timeout is 2 min
+        expect(callbackSpy).toHaveBeenNthCalledWith(1, [
+          {
+            clientId: '1',
+            data: {},
+            isConnected: true,
+          },
+          {
+            clientId: '2',
+            data: {},
+            isConnected: true,
+          },
+        ]);
+      });
     });
   });
 });

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -20,7 +20,7 @@ class Spaces {
 
     if (this.spaces[name]) return this.spaces[name];
 
-    const space = new Space(name, this.ably);
+    const space = new Space(name, this.ably, options);
     this.spaces[name] = space;
     return space;
   }

--- a/src/options/SpaceOptions.d.ts
+++ b/src/options/SpaceOptions.d.ts
@@ -1,5 +1,5 @@
 type SpaceOptions = {
-  data?: any;
+  offlineTimeout?: number;
 };
 
 export default SpaceOptions;

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -1,0 +1,41 @@
+import { SpaceMembersUpdateEvent } from '../../Space';
+
+const enterPresenceMessage = {
+  clientId: '1',
+  data: '{}',
+  action: 'enter',
+  connectionId: '1',
+  id: '1',
+  encoding: 'json',
+  timestamp: 1,
+};
+
+const updatePresenceMessage = {
+  ...enterPresenceMessage,
+  data: '{ "a": 1 }',
+  action: 'update',
+};
+
+const leavePresenceMessage = {
+  ...enterPresenceMessage,
+  action: 'leave',
+};
+
+const createPresenceMessage = (type, override?) => {
+  switch (type) {
+    case 'enter':
+      return { ...enterPresenceMessage, ...override };
+    case 'update':
+      return { ...updatePresenceMessage, ...override };
+    case 'leave':
+      return { ...leavePresenceMessage, ...override };
+    default:
+      throw new Error(`Invalid test event type argument: ${type}`);
+  }
+};
+
+const createPresenceEvent = (type, override?) => {
+  return new SpaceMembersUpdateEvent(createPresenceMessage(type, override));
+};
+
+export { createPresenceMessage, createPresenceEvent };


### PR DESCRIPTION
Add a method to watch all changes to `members` in a space.

Note, because of a merge error, this PR also contains the commits from:
- https://github.com/ably-labs/spaces/pull/9
- https://github.com/ably-labs/spaces/pull/10