### PR TITLE
[MMB-5 ] add lastEvent to SpaceMember

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -48,8 +48,8 @@ describe('Space (mockClient)', () => {
       ]);
       const spaceMembers = await space.enter();
       expect(spaceMembers).toEqual([
-        { clientId: '1', isConnected: true, data: {} },
-        { clientId: '2', isConnected: true, data: { a: 1 } },
+        { clientId: '1', isConnected: true, data: {}, lastEvent: { name: 'enter', timestamp: 1 } },
+        { clientId: '2', isConnected: true, data: { a: 1 }, lastEvent: { name: 'update', timestamp: 1 } },
       ]);
     });
   });
@@ -98,6 +98,7 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: {},
           isConnected: true,
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
 
@@ -107,11 +108,13 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: {},
           isConnected: true,
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
         {
           clientId: '2',
           data: { a: 1 },
           isConnected: true,
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
     });
@@ -126,6 +129,7 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: {},
           isConnected: true,
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
 
@@ -135,6 +139,7 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: { a: 1 },
           isConnected: true,
+          lastEvent: { name: 'update', timestamp: 1 },
         },
       ]);
     });
@@ -149,6 +154,7 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: {},
           isConnected: true,
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
 
@@ -158,6 +164,7 @@ describe('Space (mockClient)', () => {
           clientId: '1',
           data: {},
           isConnected: false,
+          lastEvent: { name: 'leave', timestamp: 1 },
         },
       ]);
     });
@@ -181,6 +188,7 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
 
@@ -190,6 +198,7 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: false,
+            lastEvent: { name: 'leave', timestamp: 1 },
           },
         ]);
 
@@ -208,11 +217,13 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
 
@@ -222,11 +233,13 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: false,
+            lastEvent: { name: 'leave', timestamp: 1 },
           },
           {
             clientId: '2',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
 
@@ -237,11 +250,13 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
 
@@ -251,11 +266,13 @@ describe('Space (mockClient)', () => {
             clientId: '1',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
             data: {},
             isConnected: true,
+            lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
       });

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -11,6 +11,10 @@ type SpaceMember = {
   clientId: string;
   isConnected: boolean;
   data: { [key: string]: any };
+  lastEvent: {
+    name: Types.PresenceAction;
+    timestamp: number;
+  };
 };
 
 type SpaceLeaver = {
@@ -57,6 +61,10 @@ class Space extends EventTarget {
       clientId: message.clientId as string,
       isConnected: message.action !== 'leave',
       data: JSON.parse(message.data as string),
+      lastEvent: {
+        name: message.action,
+        timestamp: message.timestamp,
+      },
     };
   }
 


### PR DESCRIPTION
This data gives users an opportunity to change the UI based on what specific event was captured, as well as its timestamp.

The main use case here is to get the timestamp for the “leave” event, and show a user as “inactive” before removing them from the members set.