### PR TITLE
bugfix: remove JSON.parse from member transform

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -102,7 +102,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: '{ "a": 1 }' }));
+      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: { a: 1 } }));
       expect(callbackSpy).toHaveBeenNthCalledWith(1, [
         {
           clientId: '1',
@@ -133,7 +133,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('update', { data: '{ "a": 1 }' }));
+      space.dispatchEvent(createPresenceEvent('update', { data: { a: 1 } }));
       expect(callbackSpy).toHaveBeenNthCalledWith(1, [
         {
           clientId: '1',

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -60,7 +60,7 @@ class Space extends EventTarget {
     return {
       clientId: message.clientId as string,
       isConnected: message.action !== 'leave',
-      data: JSON.parse(message.data as string),
+      data: message.data,
       lastEvent: {
         name: message.action,
         timestamp: message.timestamp,

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -2,7 +2,7 @@ import { SpaceMembersUpdateEvent } from '../../Space';
 
 const enterPresenceMessage = {
   clientId: '1',
-  data: '{}',
+  data: {},
   action: 'enter',
   connectionId: '1',
   id: '1',
@@ -12,7 +12,7 @@ const enterPresenceMessage = {
 
 const updatePresenceMessage = {
   ...enterPresenceMessage,
-  data: '{ "a": 1 }',
+  data: { a: 1 },
   action: 'update',
 };
 


### PR DESCRIPTION
We've removed previously the stringify from the .enter method to keep compatibility with what happens in underlaying APIs.

This .parse was missed from that refactor.