### PR TITLE
Fix members not being removed after timeout

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -102,7 +102,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: '{ "a": 1 }' }));
+      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: { a: 1 } }));
       expect(callbackSpy).toHaveBeenNthCalledWith(1, [
         {
           clientId: '1',
@@ -133,7 +133,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('update', { data: '{ "a": 1 }' }));
+      space.dispatchEvent(createPresenceEvent('update', { data: { a: 1 } }));
       expect(callbackSpy).toHaveBeenNthCalledWith(1, [
         {
           clientId: '1',

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -203,7 +203,9 @@ describe('Space (mockClient)', () => {
         ]);
 
         vi.advanceTimersByTime(130_000);
+
         expect(callbackSpy).toHaveBeenNthCalledWith(1, []);
+        expect(callbackSpy).toHaveBeenCalledTimes(3);
       });
 
       it<SpaceTestContext>('does not remove a member that has rejoined', async ({ space }) => {
@@ -275,6 +277,8 @@ describe('Space (mockClient)', () => {
             lastEvent: { name: 'enter', timestamp: 1 },
           },
         ]);
+
+        expect(callbackSpy).toHaveBeenCalledTimes(4);
       });
     });
   });

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -60,7 +60,7 @@ class Space extends EventTarget {
     return {
       clientId: message.clientId as string,
       isConnected: message.action !== 'leave',
-      data: JSON.parse(message.data as string),
+      data: message.data,
       lastEvent: {
         name: message.action,
         timestamp: message.timestamp,

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -27,8 +27,9 @@ const SPACE_OPTIONS_DEFAULTS = {
 };
 
 class SpaceMembersUpdateEvent extends Event {
-  constructor(public message?: Types.PresenceMessage) {
+  constructor(public message?: Types.PresenceMessage, public markForRemoval?: boolean) {
     super('membersUpdate', {});
+    this.markForRemoval = typeof markForRemoval !== 'boolean' ? false : markForRemoval;
   }
 }
 
@@ -76,11 +77,7 @@ class Space extends EventTarget {
 
   private addLeaver(message: Types.PresenceMessage) {
     const timeoutCallback = () => {
-      const membersIndex = this.members.findIndex(({ clientId }) => clientId === message.clientId);
-      const leaverIndex = this.leavers.findIndex(({ clientId }) => clientId === message.clientId);
-
-      if (membersIndex >= 0) this.members.splice(membersIndex, 1);
-      if (leaverIndex >= 0) this.removeLeaver(leaverIndex);
+      this.dispatchEvent(new SpaceMembersUpdateEvent(message, true));
     };
 
     this.leavers.push({
@@ -97,28 +94,38 @@ class Space extends EventTarget {
     clearTimeout(this.leavers[leaverIndex].timeoutId);
   }
 
-  private updateMembersFromPresenceMessage(message: Types.PresenceMessage): SpaceMember[] {
-    const memberIndex = this.members.findIndex(({ clientId }) => clientId === message.clientId);
+  private updateLeavers(message: Types.PresenceMessage) {
+    const index = this.leavers.findIndex(({ clientId }) => clientId === message.clientId);
 
-    if (memberIndex >= 0) {
-      this.members[memberIndex] = this.createSpaceMemberFromPresenceMember(message);
+    if (message.action === 'leave' && index < 0) {
+      this.addLeaver(message);
+    } else if (message.action === 'leave' && index >= 0) {
+      this.resetLeaver(index);
+      this.removeLeaver(index);
+      this.addLeaver(message);
+    } else if (index >= 0) {
+      this.resetLeaver(index);
+      this.removeLeaver(index);
+    }
+  }
+
+  private updateMembers(message: Types.PresenceMessage) {
+    const index = this.members.findIndex(({ clientId }) => clientId === message.clientId);
+    const spaceMember = this.createSpaceMemberFromPresenceMember(message);
+
+    if (index >= 0) {
+      this.members[index] = spaceMember;
     } else {
-      this.members.push(this.createSpaceMemberFromPresenceMember(message));
+      this.members.push(spaceMember);
     }
+  }
 
-    const leaverIndex = this.leavers.findIndex(({ clientId }) => clientId === message.clientId);
+  private removeMember(clientId) {
+    const index = this.members.findIndex((member) => member.clientId === clientId);
 
-    if (message.action === 'leave' && leaverIndex < 0) {
-      this.addLeaver(message);
-    } else if (message.action === 'leave' && leaverIndex >= 0) {
-      this.resetLeaver(leaverIndex);
-      this.addLeaver(message);
-    } else if (leaverIndex >= 0) {
-      this.resetLeaver(leaverIndex);
-      this.removeLeaver(leaverIndex);
+    if (index >= 0) {
+      this.members.splice(index, 1);
     }
-
-    return this.members;
   }
 
   private subscribeToPresence() {
@@ -149,7 +156,13 @@ class Space extends EventTarget {
         // By default, we only return data about other connected clients, not the whole set
         if (event.message.clientId === this.clientId) return;
 
-        this.updateMembersFromPresenceMessage(event.message);
+        if (event.markForRemoval) {
+          this.removeMember(event.message.clientId);
+        } else {
+          this.updateLeavers(event.message);
+          this.updateMembers(event.message);
+        }
+
         callback(this.members);
       });
     } else {

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -2,7 +2,7 @@ import { SpaceMembersUpdateEvent } from '../../Space';
 
 const enterPresenceMessage = {
   clientId: '1',
-  data: '{}',
+  data: {},
   action: 'enter',
   connectionId: '1',
   id: '1',
@@ -12,7 +12,7 @@ const enterPresenceMessage = {
 
 const updatePresenceMessage = {
   ...enterPresenceMessage,
-  data: '{ "a": 1 }',
+  data: { a: 1 },
   action: 'update',
 };
 


### PR DESCRIPTION
The previous implementation worked only on mutating the array but never actually dispatched the event.

This was not caught in tests because the matchers in test also kept the reference to the mutated array.