### PR TITLE
Fix: NPM release yml incorrectly passes action-validator validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Install dependencies
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm ci
-        run: npm run build
-        run: npm --no-git-tag-version version from-git
-        run: npm publish --access=public
+        run: |
+          npm ci
+          npm run build
+          npm --no-git-tag-version version from-git
+          npm publish --access=public


### PR DESCRIPTION
GitHub Actions don't allow multiple keys, meanwhile the `action-validator` thinks that's fine.

Conversely, GitHub Actions should allow multiple run commands like:

```
  - run: npm ci
  - run: npm run build --if-present
  - run: npm test
 ```

- but the `action-validator` thinks this is an error.

This fix should allow the YAML to be valid for both.