### PR TITLE
FIX: Remove step to infer release from Git Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access=public
+          npm publish --access=public --tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.13.0"
-      - name: Install dependencies
+      - name: Install dependencies and publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm --no-git-tag-version version from-git
           npm publish --access=public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access=public --tag
+          npm publish --access=public


### PR DESCRIPTION
It doesn't seem possible to both keep a permanent committed version in package.json and to apply a version to an NPM package from a git tag.

This PR removes the step to apply a version to an NPM package from a git tag.