### PR TITLE
[MMB-52] Add support for multiple connections in line with method laid out in MMB-42

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -48,8 +48,20 @@ describe('Space (mockClient)', () => {
       ]);
       const spaceMembers = await space.enter();
       expect(spaceMembers).toEqual<SpaceMember[]>([
-        { clientId: '1', connections: ['1'], isConnected: true, profileData: {}, lastEvent: { name: 'enter', timestamp: 1 } },
-        { clientId: '2', connections: ['2'], isConnected: true, profileData: { a: 1 }, lastEvent: { name: 'update', timestamp: 1 } },
+        {
+          clientId: '1',
+          connections: ['1'],
+          isConnected: true,
+          profileData: {},
+          lastEvent: { name: 'enter', timestamp: 1 },
+        },
+        {
+          clientId: '2',
+          connections: ['2'],
+          isConnected: true,
+          profileData: { a: 1 },
+          lastEvent: { name: 'update', timestamp: 1 },
+        },
       ]);
     });
 
@@ -60,7 +72,7 @@ describe('Space (mockClient)', () => {
       await space.enter();
       const member = space.getMemberFromConnection('testConnectionId');
       expect(member).toEqual({
-        clientId: "1",
+        clientId: '1',
         connections: ['testConnectionId'],
         isConnected: true,
         lastEvent: {

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -44,12 +44,12 @@ describe('Space (mockClient)', () => {
     it<SpaceTestContext>('returns current space members', async ({ presence, space }) => {
       vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
         createPresenceMessage('enter'),
-        createPresenceMessage('update', { clientId: '2' }),
+        createPresenceMessage('update', { clientId: '2', connectionId: '2' }),
       ]);
       const spaceMembers = await space.enter();
       expect(spaceMembers).toEqual<SpaceMember[]>([
-        { clientId: '1', isConnected: true, profileData: {}, lastEvent: { name: 'enter', timestamp: 1 } },
-        { clientId: '2', isConnected: true, profileData: { a: 1 }, lastEvent: { name: 'update', timestamp: 1 } },
+        { clientId: '1', connections: ['1'], isConnected: true, profileData: {}, lastEvent: { name: 'enter', timestamp: 1 } },
+        { clientId: '2', connections: ['2'], isConnected: true, profileData: { a: 1 }, lastEvent: { name: 'update', timestamp: 1 } },
       ]);
     });
   });
@@ -96,22 +96,25 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: {},
           isConnected: true,
           lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', data: { a: 1 } }));
+      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', connectionId: '2', data: { a: 1 } }));
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: {},
           isConnected: true,
           lastEvent: { name: 'enter', timestamp: 1 },
         },
         {
           clientId: '2',
+          connections: ['2'],
           profileData: { a: 1 },
           isConnected: true,
           lastEvent: { name: 'enter', timestamp: 1 },
@@ -127,6 +130,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: {},
           isConnected: true,
           lastEvent: { name: 'enter', timestamp: 1 },
@@ -137,6 +141,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: { a: 1 },
           isConnected: true,
           lastEvent: { name: 'update', timestamp: 1 },
@@ -152,6 +157,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: {},
           isConnected: true,
           lastEvent: { name: 'enter', timestamp: 1 },
@@ -162,6 +168,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
+          connections: ['1'],
           profileData: {},
           isConnected: false,
           lastEvent: { name: 'leave', timestamp: 1 },
@@ -186,6 +193,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
@@ -196,6 +204,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: false,
             lastEvent: { name: 'leave', timestamp: 1 },
@@ -213,16 +222,18 @@ describe('Space (mockClient)', () => {
         space.on('membersUpdate', callbackSpy);
 
         space.dispatchEvent(createPresenceEvent('enter'));
-        space.dispatchEvent(createPresenceEvent('enter', { clientId: '2' }));
+        space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', connectionId: '2' }));
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
+            connections: ['2'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
@@ -233,12 +244,14 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: false,
             lastEvent: { name: 'leave', timestamp: 1 },
           },
           {
             clientId: '2',
+            connections: ['2'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
@@ -250,12 +263,14 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
+            connections: ['2'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
@@ -266,12 +281,14 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
+            connections: ['1'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },
           },
           {
             clientId: '2',
+            connections: ['2'],
             profileData: {},
             isConnected: true,
             lastEvent: { name: 'enter', timestamp: 1 },

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -52,6 +52,26 @@ describe('Space (mockClient)', () => {
         { clientId: '2', connections: ['2'], isConnected: true, profileData: { a: 1 }, lastEvent: { name: 'update', timestamp: 1 } },
       ]);
     });
+
+    it<SpaceTestContext>('retrieves active space members by connection', async ({ presence, space }) => {
+      vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
+        createPresenceMessage('enter', { connectionId: 'testConnectionId' }),
+      ]);
+      await space.enter();
+      const member = space.getMemberFromConnection('testConnectionId');
+      expect(member).toEqual({
+        clientId: "1",
+        connections: ['testConnectionId'],
+        isConnected: true,
+        lastEvent: {
+          name: 'enter',
+          timestamp: 1,
+        },
+        profileData: {},
+      });
+      const noMember = space.getMemberFromConnection('nonExistentConnectionId');
+      expect(noMember).toBe(undefined);
+    });
   });
 
   describe('leave', () => {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -61,7 +61,6 @@ class Space extends EventTarget {
   getMemberFromConnection(connectionId: string){
     return this.members.find((m) => m.connections.includes(connectionId));
   }
-  
 
   private updateOrCreateMember(message: Types.PresenceMessage): SpaceMember {
     const member = this.getMemberFromConnection(message.connectionId);

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -58,7 +58,7 @@ class Space extends EventTarget {
     this.channel = this.client.channels.get(this.channelName);
   }
 
-  getMemberFromConnection(connectionId: string){
+  getMemberFromConnection(connectionId: string) {
     return this.members.find((m) => m.connections.includes(connectionId));
   }
 
@@ -69,17 +69,17 @@ class Space extends EventTarget {
       timestamp: message.timestamp,
     };
 
-    if(!member){
+    if (!member) {
       return {
         clientId: message.clientId as string,
         isConnected: message.action !== 'leave',
         profileData: message.data,
         lastEvent,
-        connections: [message.connectionId]
+        connections: [message.connectionId],
       };
     }
 
-    if(!member.connections.includes(message.connectionId)){
+    if (!member.connections.includes(message.connectionId)) {
       member.connections.push(message.connectionId);
     }
 


### PR DESCRIPTION
[Jira ticket](https://ably.atlassian.net/browse/MMB-52)

[MMB-42 Document](https://docs.google.com/document/d/1nQ-AHLwAvScDiZmpFpf_QMvETAcN1WUFn8NdluJZV8M/edit#)

Motivation: to support multiple connections per client. Adds method to retrieve client by connectionId and basic logic to update the connectionId.