### PR TITLE
FIX: Some Ably Clients not supported by Ably Spaces API

### DIFF
--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -10,7 +10,7 @@ class Spaces {
 
   constructor(optionsOrAbly: Types.RealtimePromise | Types.ClientOptions | string) {
     this.spaces = {};
-    if (optionsOrAbly instanceof Realtime) {
+    if (optionsOrAbly['options']) {
       this.ably = optionsOrAbly as Types.RealtimePromise;
       this.addAgent(this.ably['options'], false);
     } else {


### PR DESCRIPTION
Currently, attempting to do this:

```
import * as Ably from 'ably/promises';
...
  const ably = new Ably.Realtime.Promise({ authUrl: `/api/ably-token-request?clientId=${clientId}`, clientId });

  const spaces = new Spaces(ably);
```

Will result in a confusing error due to the agent adding code and instanceof detecting that we are using `Realtime2`.

I propose that we fix this by changing the instanceof check to a duck-typing check, as this is all we are interested in at this point.

There is a possible point of confusion, in that the options object could theoretically have another 'options' key added at some point. This should not happen from the Ably side, and I don't think we should support on the client side (who would have to avoid TypeScript to get this to work, also), either.
I see two alternatives:
* if we can invert this check & ensure we are **not** using Types.ClientOptions or a string instead, we should do that; I don't think that we can do this easily enough, but would be glad to hear if I am wrong
* we can change the constructor to require options & client separately; I predict confusion arising from this however we implement it, as they are mutually exclusive