### PR TITLE
Use EventEmitter class over EventTarget

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -102,7 +102,7 @@ describe('Space (mockClient)', () => {
       new Space('test', client);
       expect(spy).toHaveBeenCalledOnce();
     });
-    
+
     it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {
       const spy = vi.fn();
       space['onPresenceUpdate'](createPresenceMessage('enter', { clientId: client.auth.clientId }));
@@ -321,12 +321,22 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenCalledTimes(4);
       });
 
-      it<SpaceTestContext>('unsubscribes when the unsubscribe function is called', async ({ space }) => {
+      it<SpaceTestContext>('unsubscribes when off is called', async ({ space }) => {
         const spy = vi.fn();
-        const unsubscribeFunc = space.on('membersUpdate', spy);
-        space.dispatchEvent(createPresenceEvent('enter', { clientId: '123456' }));
-        unsubscribeFunc();
-        space.dispatchEvent(createPresenceEvent('enter', { clientId: '123456' }));
+        space.on('membersUpdate', spy);
+        createPresenceEvent(space, 'enter', { clientId: '123456' });
+        space.off('membersUpdate', spy);
+        createPresenceEvent(space, 'enter', { clientId: '123456' });
+
+        expect(spy).toHaveBeenCalledOnce();
+      });
+
+      it<SpaceTestContext>('unsubscribes when off is called with no arguments', async ({ space }) => {
+        const spy = vi.fn();
+        space.on('membersUpdate', spy);
+        createPresenceEvent(space, 'enter', { clientId: '123456' });
+        space.off();
+        createPresenceEvent(space, 'enter', { clientId: '123456' });
 
         expect(spy).toHaveBeenCalledOnce();
       });

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -95,27 +95,17 @@ describe('Space (mockClient)', () => {
   });
 
   describe('on', () => {
-    it<SpaceTestContext>('subscribes to presence updates', async ({ presence, space }) => {
+    it('subscribes to presence updates', async () => {
+      const client = new Realtime({});
+      const presence = client.channels.get('').presence;
       const spy = vi.spyOn(presence, 'subscribe');
-      space.on('membersUpdate', () => {});
+      new Space('test', client);
       expect(spy).toHaveBeenCalledOnce();
-    });
-
-    it<SpaceTestContext>('errors if an unrecognized event is passed in', async ({ space }) => {
-      await space.enter();
-      // @ts-expect-error
-      expect(() => space.on('invalidEvent', () => {})).toThrowError('Event "invalidEvent" is unsupported');
-    });
-
-    it<SpaceTestContext>('subscribes to presence events', async ({ presence, space }) => {
-      const spy = vi.spyOn(presence, 'subscribe');
-      space.on('membersUpdate', vi.fn());
-      expect(spy).toHaveBeenCalled();
     });
 
     it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {
       const spy = vi.fn();
-      space.dispatchEvent(createPresenceEvent('enter', { clientId: client.auth.clientId }));
+      space['onPresenceUpdate'](createPresenceMessage('enter', { clientId: client.auth.clientId }));
       space.on('membersUpdate', spy);
       expect(spy).not.toHaveBeenCalled();
     });
@@ -124,7 +114,8 @@ describe('Space (mockClient)', () => {
       const callbackSpy = vi.fn();
       space.on('membersUpdate', callbackSpy);
 
-      space.dispatchEvent(createPresenceEvent('enter'));
+      createPresenceEvent(space, 'enter');
+
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -135,7 +126,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', connectionId: '2', data: { a: 1 } }));
+      createPresenceEvent(space, 'enter', { clientId: '2', connectionId: '2', data: { a: 1 } });
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -158,7 +149,7 @@ describe('Space (mockClient)', () => {
       const callbackSpy = vi.fn();
       space.on('membersUpdate', callbackSpy);
 
-      space.dispatchEvent(createPresenceEvent('enter'));
+      createPresenceEvent(space, 'enter');
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -169,7 +160,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('update', { data: { a: 1 } }));
+      createPresenceEvent(space, 'update', { data: { a: 1 } });
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -185,7 +176,7 @@ describe('Space (mockClient)', () => {
       const callbackSpy = vi.fn();
       space.on('membersUpdate', callbackSpy);
 
-      space.dispatchEvent(createPresenceEvent('enter'));
+      createPresenceEvent(space, 'enter');
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -196,7 +187,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      space.dispatchEvent(createPresenceEvent('leave'));
+      createPresenceEvent(space, 'leave');
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -221,7 +212,7 @@ describe('Space (mockClient)', () => {
         const callbackSpy = vi.fn();
         space.on('membersUpdate', callbackSpy);
 
-        space.dispatchEvent(createPresenceEvent('enter'));
+        createPresenceEvent(space, 'enter');
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
@@ -232,7 +223,7 @@ describe('Space (mockClient)', () => {
           },
         ]);
 
-        space.dispatchEvent(createPresenceEvent('leave'));
+        createPresenceEvent(space, 'leave');
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
@@ -253,8 +244,8 @@ describe('Space (mockClient)', () => {
         const callbackSpy = vi.fn();
         space.on('membersUpdate', callbackSpy);
 
-        space.dispatchEvent(createPresenceEvent('enter'));
-        space.dispatchEvent(createPresenceEvent('enter', { clientId: '2', connectionId: '2' }));
+        createPresenceEvent(space, 'enter');
+        createPresenceEvent(space, 'enter', { clientId: '2', connectionId: '2' });
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
@@ -272,7 +263,7 @@ describe('Space (mockClient)', () => {
           },
         ]);
 
-        space.dispatchEvent(createPresenceEvent('leave'));
+        createPresenceEvent(space, 'leave');
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
@@ -291,7 +282,7 @@ describe('Space (mockClient)', () => {
         ]);
 
         vi.advanceTimersByTime(60_000);
-        space.dispatchEvent(createPresenceEvent('enter'));
+        createPresenceEvent(space, 'enter');
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -6,9 +6,6 @@ import EventEmitter from './utilities/EventEmitter';
 // Unique prefix to avoid conflicts with channels
 const SPACE_CHANNEL_PREFIX = '_ably_space_';
 
-
-type UnsubscribeFunc = () => void;
-
 export type SpaceMember = {
   clientId: string;
   isConnected: boolean;

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -1,11 +1,10 @@
 import { Types } from 'ably';
 
 import SpaceOptions from './options/SpaceOptions';
+import EventEmitter from './utilities/EventEmitter';
 
 // Unique prefix to avoid conflicts with channels
 const SPACE_CHANNEL_PREFIX = '_ably_space_';
-
-type SpaceEvents = 'membersUpdate';
 
 export type SpaceMember = {
   clientId: string;
@@ -27,14 +26,7 @@ const SPACE_OPTIONS_DEFAULTS = {
   offlineTimeout: 120_000,
 };
 
-class SpaceMembersUpdateEvent extends Event {
-  constructor(public message?: Types.PresenceMessage, public markForRemoval?: boolean) {
-    super('membersUpdate', {});
-    this.markForRemoval = typeof markForRemoval !== 'boolean' ? false : markForRemoval;
-  }
-}
-
-class Space extends EventTarget {
+class Space extends EventEmitter {
   private channelName: string;
   private clientId: string;
   private channel: Types.RealtimeChannelPromise;
@@ -42,20 +34,24 @@ class Space extends EventTarget {
   private leavers: SpaceLeaver[];
   private options: SpaceOptions;
 
-  eventTarget: EventTarget;
-
   constructor(private name: string, private client: Types.RealtimePromise, options?: SpaceOptions) {
     super();
     this.options = { ...SPACE_OPTIONS_DEFAULTS, ...options };
     this.clientId = this.client.auth.clientId;
     this.members = [];
     this.leavers = [];
+    this.onPresenceUpdate = this.onPresenceUpdate.bind(this);
     this.setChannel(this.name);
   }
 
   private setChannel(rootName: string) {
+    // Remove the old subscription if the channel is switching
+    if (this.channel) {
+      this.channel.presence.unsubscribe(this.onPresenceUpdate);
+    }
     this.channelName = `${SPACE_CHANNEL_PREFIX}${rootName}`;
     this.channel = this.client.channels.get(this.channelName);
+    this.channel.presence.subscribe(this.onPresenceUpdate);
   }
 
   getMemberFromConnection(connectionId: string) {
@@ -98,7 +94,8 @@ class Space extends EventTarget {
 
   private addLeaver(message: Types.PresenceMessage) {
     const timeoutCallback = () => {
-      this.dispatchEvent(new SpaceMembersUpdateEvent(message, true));
+      this.removeMember(message.clientId);
+      this.emit('membersUpdate', this.members);
     };
 
     this.leavers.push({
@@ -149,10 +146,15 @@ class Space extends EventTarget {
     }
   }
 
-  private subscribeToPresence() {
-    this.channel.presence.subscribe((message) => {
-      this.dispatchEvent(new SpaceMembersUpdateEvent(message));
-    });
+  private onPresenceUpdate(message: Types.PresenceMessage) {
+    if (!message) return;
+    // By default, we only return data about other connected clients, not the whole set
+    if (message.clientId === this.clientId) return;
+
+    this.updateLeavers(message);
+    this.updateMembers(message);
+
+    this.emit('membersUpdate', this.members);
   }
 
   async enter(profileData?: unknown) {
@@ -168,30 +170,6 @@ class Space extends EventTarget {
   leave(data?: unknown) {
     return this.channel.presence.leave(data);
   }
-
-  on(spaceEvent: SpaceEvents, callback) {
-    if (spaceEvent === 'membersUpdate') {
-      this.subscribeToPresence();
-      this.addEventListener('membersUpdate', (event: SpaceMembersUpdateEvent) => {
-        if (!event.message) return;
-        // By default, we only return data about other connected clients, not the whole set
-        if (event.message.clientId === this.clientId) return;
-
-        if (event.markForRemoval) {
-          this.removeMember(event.message.clientId);
-        } else {
-          this.updateLeavers(event.message);
-          this.updateMembers(event.message);
-        }
-
-        callback(this.members);
-      });
-    } else {
-      // TODO: align with ably-js error policy here
-      throw new Error(`Event "${spaceEvent}" is unsupported`);
-    }
-  }
 }
 
-export { SpaceMembersUpdateEvent };
 export default Space;

--- a/src/utilities/EventEmitter.ts
+++ b/src/utilities/EventEmitter.ts
@@ -1,0 +1,326 @@
+function callListener(eventThis: { event: string }, listener: Function, args: unknown[]) {
+  try {
+    listener.apply(eventThis, args);
+  } catch (e) {
+    console.error('EventEmitter.emit()',
+      'Unexpected listener exception: ' + e + '; stack = ' + (e && (e as Error).stack))
+  }
+}
+
+/**
+ * Remove listeners that match listener
+ * @param targetListeners is an array of listener arrays or event objects with arrays of listeners
+ * @param listener the listener callback to remove
+ * @param eventFilter (optional) event name instructing the function to only remove listeners for the specified event
+ */
+function removeListener(targetListeners: any, listener: Function, eventFilter?: string) {
+  let listeners: Record<string, unknown>;
+  let index;
+  let eventName;
+
+  for (let targetListenersIndex = 0; targetListenersIndex < targetListeners.length; targetListenersIndex++) {
+    listeners = targetListeners[targetListenersIndex];
+    if (eventFilter) {
+      listeners = listeners[eventFilter] as Record<string, unknown>;
+    }
+
+    if (Array.isArray(listeners)) {
+      while ((index = listeners.indexOf(listener)) !== -1) {
+        listeners.splice(index, 1);
+      }
+      /* If events object has an event name key with no listeners then
+					remove the key to stop the list growing indefinitely */
+      if (eventFilter && listeners.length === 0) {
+        delete targetListeners[targetListenersIndex][eventFilter];
+      }
+    } else if (isObject(listeners)) {
+      /* events */
+      for (eventName in listeners) {
+        if (Object.prototype.hasOwnProperty.call(listeners, eventName) && Array.isArray(listeners[eventName])) {
+          removeListener([listeners], listener, eventName);
+        }
+      }
+    }
+  }
+}
+
+// Equivalent of Platform.config.inspect from ably-js for browser/RN
+function inspect(args: any): string{
+  return JSON.stringify(args);
+}
+
+// Equivalent of Util.isObject from ably-js
+function isObject(arg: unknown): arg is Record<string, unknown> {
+  return Object.prototype.toString.call(arg).slice(8, -1) === '[object Object]';
+}
+
+
+// Equivalent of Platform.isEmptyArg from ably-js
+function isEmptyArg(arg: unknown): arg is null | undefined {
+  return arg === null || arg === undefined;
+}
+
+export default class EventEmitter {
+  any: Array<Function>;
+  events: Record<string, Array<Function>>;
+  anyOnce: Array<Function>;
+  eventsOnce: Record<string, Array<Function>>;
+
+  constructor() {
+    this.any = [];
+    this.events = Object.create(null);
+    this.anyOnce = [];
+    this.eventsOnce = Object.create(null);
+  }
+
+  /**
+   * Add an event listener
+   * @param listener the listener to be called
+   */
+  on(listener: Function): void;
+
+  /**
+   * Add an event listener
+   * @param event (optional) the name of the event to listen to
+   * @param listener the listener to be called
+   */
+  on(event: null | string | string[], listener: Function): void;
+
+  on(...args: unknown[]) {
+    if (args.length === 1) {
+      const listener = args[0];
+      if (typeof listener === 'function') {
+        this.any.push(listener);
+      } else {
+        throw new Error('EventListener.on(): Invalid arguments: ' + inspect(args));
+      }
+    }
+    if (args.length === 2) {
+      const [event, listener] = args;
+      if (typeof listener !== 'function') {
+        throw new Error('EventListener.on(): Invalid arguments: ' + inspect(args));
+      }
+      if (isEmptyArg(event)) {
+        this.any.push(listener);
+      } else if (Array.isArray(event)) {
+        event.forEach((eventName) => {
+          this.on(eventName, listener);
+        });
+      } else {
+        if (typeof event !== 'string') {
+          throw new Error('EventListener.on(): Invalid arguments: ' + inspect(args));
+        }
+        const listeners = this.events[event] || (this.events[event] = []);
+        listeners.push(listener);
+      }
+    }
+  }
+
+  /**
+   * Remove one or more event listeners
+   * @param listener (optional) the listener to remove. If not
+   *        supplied, all listeners are removed.
+   */
+  off(listener?: Function): void;
+
+  /**
+   * Remove one or more event listeners
+   * @param event (optional) the name of the event whose listener
+   *        is to be removed. If not supplied, the listener is
+   *        treated as an 'any' listener
+   * @param listener (optional) the listener to remove. If not
+   *        supplied, all listeners are removed.
+   */
+  off(event: string | string[] | null, listener?: Function | null): void;
+
+  off(...args: unknown[]) {
+    if (args.length == 0 || (isEmptyArg(args[0]) && isEmptyArg(args[1]))) {
+      this.any = [];
+      this.events = Object.create(null);
+      this.anyOnce = [];
+      this.eventsOnce = Object.create(null);
+      return;
+    }
+    const [firstArg, secondArg] = args;
+    let listener: Function | null = null;
+    let event: unknown = null;
+    if (args.length === 1 || !secondArg) {
+      if (typeof firstArg === 'function') {
+        /* we take this to be the listener and treat the event as "any" .. */
+        listener = firstArg;
+      } else {
+        event = firstArg;
+      }
+      /* ... or we take event to be the actual event name and listener to be all */
+    } else {
+      if (typeof secondArg !== 'function') {
+        throw new Error('EventEmitter.off(): invalid arguments:' + inspect(args));
+      }
+      [event, listener] = [firstArg, secondArg];
+    }
+
+    if (listener && isEmptyArg(event)) {
+      removeListener([this.any, this.events, this.anyOnce, this.eventsOnce], listener);
+      return;
+    }
+
+    if (Array.isArray(event)) {
+      event.forEach((eventName) => {
+        this.off(eventName, listener);
+      });
+      return;
+    }
+
+    /* "normal" case where event is an actual event */
+    if (typeof event !== 'string') {
+      throw new Error('EventEmitter.off(): invalid arguments:' + inspect(args));
+    }
+    if (listener) {
+      removeListener([this.events, this.eventsOnce], listener, event);
+    } else {
+      delete this.events[event];
+      delete this.eventsOnce[event];
+    }
+  }
+
+  /**
+   * Get the array of listeners for a given event; excludes once events
+   * @param event (optional) the name of the event, or none for 'any'
+   * @return array of events, or null if none
+   */
+  listeners(event: string) {
+    if (event) {
+      const listeners = this.events[event] || [];
+      if (this.eventsOnce[event]) Array.prototype.push.apply(listeners, this.eventsOnce[event]);
+      return listeners.length ? listeners : null;
+    }
+    return this.any.length ? this.any : null;
+  }
+
+  /**
+   * Emit an event
+   * @param event the event name
+   * @param args the arguments to pass to the listener
+   */
+  emit(event: string, ...args: unknown[] /* , args... */) {
+    const eventThis = { event };
+    const listeners: Function[] = [];
+
+    if (this.anyOnce.length) {
+      Array.prototype.push.apply(listeners, this.anyOnce);
+      this.anyOnce = [];
+    }
+    if (this.any.length) {
+      Array.prototype.push.apply(listeners, this.any);
+    }
+    const eventsOnceListeners = this.eventsOnce[event];
+    if (eventsOnceListeners) {
+      Array.prototype.push.apply(listeners, eventsOnceListeners);
+      delete this.eventsOnce[event];
+    }
+    const eventsListeners = this.events[event];
+    if (eventsListeners) {
+      Array.prototype.push.apply(listeners, eventsListeners);
+    }
+
+
+    listeners.forEach(function (listener) {
+      callListener(eventThis, listener, args);
+    });
+  }
+
+  /**
+   * Listen for a single occurrence of an event
+   * @param event the name of the event to listen to
+   */
+  once(event: string): Promise<void>;
+
+  /**
+   * Listen for a single occurrence of any event
+   * @param listener the listener to be called
+   */
+  once(listener: Function): void;
+
+  /**
+   * Listen for a single occurrence of an event
+   * @param event the name of the event to listen to
+   * @param listener the listener to be called
+   */
+  once(event?: string | string[] | null, listener?: Function): void;
+
+  once(...args: unknown[]): void | Promise<void> {
+    const argCount = args.length;
+    if ((argCount === 0 || (argCount === 1 && typeof args[0] !== 'function')) && Promise) {
+      const event = args[0];
+      return new Promise((resolve) => {
+        this.once(event as string | string[] | null, resolve);
+      });
+    }
+
+    const [firstArg, secondArg] = args;
+    if (args.length === 1 && typeof firstArg === 'function') {
+      this.anyOnce.push(firstArg);
+    } else if (isEmptyArg(firstArg)) {
+      if (typeof secondArg !== 'function') {
+        throw new Error('EventEmitter.once(): Invalid arguments:' + inspect(args));
+      }
+      this.anyOnce.push(secondArg);
+    } else if (Array.isArray(firstArg)) {
+      const self = this;
+      const listenerWrapper = function (this: any) {
+        const innerArgs = Array.prototype.slice.call(arguments);
+        firstArg.forEach(function (eventName) {
+          self.off(eventName, listenerWrapper);
+        });
+        if (typeof secondArg !== 'function') {
+          throw new Error('EventEmitter.once(): Invalid arguments:' + inspect(args));
+        }
+        secondArg.apply(this, innerArgs);
+      };
+      firstArg.forEach(function (eventName) {
+        self.on(eventName, listenerWrapper);
+      });
+    } else {
+      if (typeof firstArg !== 'string') {
+        throw new Error('EventEmitter.once(): Invalid arguments:' + inspect(args));
+      }
+      const listeners = this.eventsOnce[firstArg] || (this.eventsOnce[firstArg] = []);
+      if (secondArg) {
+        if (typeof secondArg !== 'function') {
+          throw new Error('EventEmitter.once(): Invalid arguments:' + inspect(args));
+        }
+        listeners.push(secondArg);
+      }
+    }
+  }
+
+  /**
+   * Private API
+   *
+   * Listen for a single occurrence of a state event and fire immediately if currentState matches targetState
+   * @param targetState the name of the state event to listen to
+   * @param currentState the name of the current state of this object
+   * @param listener the listener to be called
+   * @param listenerArgs
+   */
+  whenState(targetState: string, currentState: string, listener: Function, ...listenerArgs: unknown[]) {
+    const eventThis = { event: targetState };
+
+    if (typeof targetState !== 'string' || typeof currentState !== 'string') {
+      throw 'whenState requires a valid event String argument';
+    }
+    if (typeof listener !== 'function' && Promise) {
+      return new Promise((resolve) => {
+        EventEmitter.prototype.whenState.apply(
+          this,
+          [targetState, currentState, resolve].concat(listenerArgs as any[]) as any
+        );
+      });
+    }
+    if (targetState === currentState) {
+      callListener(eventThis, listener, listenerArgs);
+    } else {
+      this.once(targetState, listener);
+    }
+  }
+}

--- a/src/utilities/EventEmitter.ts
+++ b/src/utilities/EventEmitter.ts
@@ -2,8 +2,10 @@ function callListener(eventThis: { event: string }, listener: Function, args: un
   try {
     listener.apply(eventThis, args);
   } catch (e) {
-    console.error('EventEmitter.emit()',
-      'Unexpected listener exception: ' + e + '; stack = ' + (e && (e as Error).stack))
+    console.error(
+      'EventEmitter.emit()',
+      'Unexpected listener exception: ' + e + '; stack = ' + (e && (e as Error).stack)
+    );
   }
 }
 
@@ -45,7 +47,7 @@ function removeListener(targetListeners: any, listener: Function, eventFilter?: 
 }
 
 // Equivalent of Platform.config.inspect from ably-js for browser/RN
-function inspect(args: any): string{
+function inspect(args: any): string {
   return JSON.stringify(args);
 }
 
@@ -53,7 +55,6 @@ function inspect(args: any): string{
 function isObject(arg: unknown): arg is Record<string, unknown> {
   return Object.prototype.toString.call(arg).slice(8, -1) === '[object Object]';
 }
-
 
 // Equivalent of Platform.isEmptyArg from ably-js
 function isEmptyArg(arg: unknown): arg is null | undefined {
@@ -222,7 +223,6 @@ export default class EventEmitter {
     if (eventsListeners) {
       Array.prototype.push.apply(listeners, eventsListeners);
     }
-
 
     listeners.forEach(function (listener) {
       callListener(eventThis, listener, args);

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -1,10 +1,9 @@
 export default class Logger {
-  static logAction(level: LogLevel, action: string, message: string){
+  static logAction(level: LogLevel, action: string, message: string) {
     console.log(level, action, message);
   }
 }
 
-
 export enum LogLevel {
-  LOG_ERROR
+  LOG_ERROR,
 }

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -1,0 +1,10 @@
+export default class Logger {
+  static logAction(level: LogLevel, action: string, message: string){
+    console.log(level, action, message);
+  }
+}
+
+
+export enum LogLevel {
+  LOG_ERROR
+}

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -1,5 +1,3 @@
-import { SpaceMembersUpdateEvent } from '../../Space';
-
 const enterPresenceMessage = {
   clientId: '1',
   data: {},
@@ -34,8 +32,8 @@ const createPresenceMessage = (type, override?) => {
   }
 };
 
-const createPresenceEvent = (type, override?) => {
-  return new SpaceMembersUpdateEvent(createPresenceMessage(type, override));
+const createPresenceEvent = (space, type, override?) => {
+  space.onPresenceUpdate(createPresenceMessage(type, override));
 };
 
 export { createPresenceMessage, createPresenceEvent };


### PR DESCRIPTION
Adds an EventEmitter based on [ably-js EventEmitter](https://github.com/ably/ably-js/blob/main/src/common/lib/util/eventemitter.ts).  Presence events are now subscribed automatically when creating a space, rather than when creating a listener, fixing MMB-75 and MMB-76 in the process. This means that there is currently no way to create a space without presence events. This is not currently a problem, if it becomes a problem we can add an option to disable it.