### PR TITLE
Update imports to use .js file extension

### DIFF
--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect, vi, beforeEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
-import Space, { SpaceMember } from './Space';
-import { createPresenceMessage } from './utilities/test/fakes';
+import Space, { SpaceMember } from './Space.js';
+import { createPresenceMessage } from './utilities/test/fakes.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -1,5 +1,5 @@
-import Space from './Space';
-import EventEmitter from './utilities/EventEmitter';
+import Space from './Space.js';
+import EventEmitter from './utilities/EventEmitter.js';
 import { Types } from 'ably';
 
 export default class Locations extends EventEmitter {

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -1,9 +1,9 @@
 import { it, describe, expect, vi, beforeEach, expectTypeOf, afterEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 
-import Space, { SpaceMember } from './Space';
-import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes';
-import Locations from './Locations';
+import Space, { SpaceMember } from './Space.js';
+import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes.js';
+import Locations from './Locations.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -2,14 +2,14 @@ import { it, describe, expect, beforeEach, afterEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 import { WebSocket } from 'mock-socket';
 
-import Space from './Space';
-import Server from './utilities/test/mock-server';
-import defaultClientConfig from './utilities/test/default-client-config';
+import Space from './Space.js';
+import Server from './utilities/test/mock-server.js';
+import defaultClientConfig from './utilities/test/default-client-config.js';
 import {
   enterPresenceAction,
   getPresenceAction,
   createChannelAction,
-} from './utilities/test/mock-server-action-responses';
+} from './utilities/test/mock-server-action-responses.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -1,8 +1,8 @@
 import { Types } from 'ably';
 
-import SpaceOptions from './options/SpaceOptions';
-import EventEmitter from './utilities/EventEmitter';
-import Locations from './Locations';
+import SpaceOptions from './options/SpaceOptions.js';
+import EventEmitter from './utilities/EventEmitter.js';
+import Locations from './Locations.js';
 
 // Unique prefix to avoid conflicts with channels
 const SPACE_CHANNEL_PREFIX = '_ably_space_';

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -2,11 +2,11 @@ import { it, describe, expect, expectTypeOf, vi, beforeEach, afterEach } from 'v
 import { Realtime, Types } from 'ably/promises';
 import { WebSocket } from 'mock-socket';
 
-import Space from './Space';
-import Spaces from './Spaces';
+import Space from './Space.js';
+import Spaces from './Spaces.js';
 
-import Server from './utilities/test/mock-server';
-import defaultClientConfig from './utilities/test/default-client-config';
+import Server from './utilities/test/mock-server.js';
+import defaultClientConfig from './utilities/test/default-client-config.js';
 
 interface SpacesTestContext {
   client: Types.RealtimePromise;

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -1,6 +1,6 @@
 import { Types, Realtime } from 'ably';
-import SpaceOptions from './options/SpaceOptions';
-import Space from './Space';
+import SpaceOptions from './options/SpaceOptions.js';
+import Space from './Space.js';
 class Spaces {
   private spaces: Record<string, Space>;
   private channel: Types.RealtimeChannelPromise;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './Spaces';
+export * from './Spaces.js';


### PR DESCRIPTION
This changes all imports to add the .js extension. This is because browsers will not resolve imports without file extensions to a .js file. Typescript will resolve .js imports to .ts internally, so all imports must be changed to have .js at the end in order to have browser compatibility. See [here](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-703190339) for more info.