### PR TITLE
[MMB-61] Add locations to demo

### DIFF
--- a/demo/app/components/avatar-stack.ts
+++ b/demo/app/components/avatar-stack.ts
@@ -32,10 +32,13 @@ const renderAvatarStack = (members) => {
   const showMembers = members.slice(0, 5);
 
   showMembers.forEach((member, index) => {
-    const li = document.createElement('li');
-    li.classList.add('ml-[-9px]', 'relative');
-    li.appendChild(renderAvatar(member, index));
-    ul.appendChild(li);
+    const avatar = renderAvatar(member, index);
+    if (avatar) {
+      const li = document.createElement('li');
+      li.classList.add('ml-[-9px]', 'relative');
+      li.appendChild(renderAvatar(member, index));
+      ul.appendChild(li);
+    }
   });
 
   container.appendChild(ul);

--- a/demo/app/components/feature-display.ts
+++ b/demo/app/components/feature-display.ts
@@ -71,15 +71,17 @@ const addLocationTracking = (
   htmlElement: HTMLElement,
   space: Space,
 ) => {
+  const qualifiedElementId = `slide-${currentSlideId}-element-${element.id}`;
   htmlElement.addEventListener('click', () => {
-    console.log(`slide-${currentSlideId}-element-${element.id}`);
-    space.locations.set(`slide-${currentSlideId}-element-${element.id}`);
+    console.log(qualifiedElementId);
+    space.locations.set(qualifiedElementId);
   });
 };
 
 const renderSlide = (containerElement: HTMLElement, slideData: SlideData, space: Space) => {
   const { id: currentSlideId } = slideData;
   containerElement.style.backgroundColor = '#FFF';
+  containerElement.innerHTML = '';
   slideData.elements.forEach((element) => {
     let slideElementFragment: HTMLElement;
     let slotElement: HTMLElement | HTMLImageElement;

--- a/demo/app/components/feature-display.ts
+++ b/demo/app/components/feature-display.ts
@@ -2,16 +2,15 @@ import { SlideData, SlideImgElement, SlideTextElement } from '../data/default-sl
 import { slideData } from '../data/slide-data';
 import { createFragment } from '../utils/dom';
 import { gradients } from '../utils/gradients';
-import { getSpaceNameFromUrl } from '../utils/url';
-import { spaces as spacesInstance } from '../script';
+import Space from '../../../src/Space';
 
-export const renderFeatureDisplay = () => {
-  renderSlidePreviewMenu();
-  renderSelectedSlide();
+export const renderFeatureDisplay = (space: Space) => {
+  renderSlidePreviewMenu(space);
+  renderSelectedSlide(space);
   renderComments();
 };
 
-const renderSlidePreviewMenu = () => {
+const renderSlidePreviewMenu = (space: Space) => {
   const slidePreviewMenuContainer = document.querySelector('#slide-left-preview-list');
   slideData.forEach((slide, i) => {
     const slidePreviewFragment = createFragment('#slide-preview') as HTMLElement;
@@ -38,7 +37,7 @@ const renderSlidePreviewMenu = () => {
       'div[data-id=slide-preview-container]',
     ) as HTMLElement;
 
-    renderSlide(slidePreviewContainer, slide);
+    renderSlide(slidePreviewContainer, slide, space);
 
     slidePreviewListItem.appendChild(slidePreviewNumber);
     slidePreviewListItem.appendChild(slidePreviewContainer);
@@ -66,18 +65,19 @@ const renderSlideImgElement = (slideElement: SlideImgElement, htmlElement: HTMLI
   return htmlElement;
 };
 
-const addLocationTracking = async (element: SlideTextElement, currentSlideId: string, htmlElement: HTMLElement) => {
-  const spaces = await spacesInstance;
-  const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
-
+const addLocationTracking = (
+  element: SlideTextElement,
+  currentSlideId: string,
+  htmlElement: HTMLElement,
+  space: Space,
+) => {
   htmlElement.addEventListener('click', () => {
-    console.log(space);
     console.log(`slide-${currentSlideId}-element-${element.id}`);
     space.locations.set(`slide-${currentSlideId}-element-${element.id}`);
   });
 };
 
-const renderSlide = (containerElement: HTMLElement, slideData: SlideData) => {
+const renderSlide = (containerElement: HTMLElement, slideData: SlideData, space: Space) => {
   const { id: currentSlideId } = slideData;
   containerElement.style.backgroundColor = '#FFF';
   slideData.elements.forEach((element) => {
@@ -87,19 +87,19 @@ const renderSlide = (containerElement: HTMLElement, slideData: SlideData) => {
       case 'title':
         slideElementFragment = createFragment('#slide-title') as HTMLElement;
         slotElement = slideElementFragment.querySelector('[data-id=slide-title-text]');
-        addLocationTracking(element, currentSlideId, slotElement);
+        addLocationTracking(element, currentSlideId, slotElement, space);
         renderSlideTextElement(element, slotElement);
         break;
       case 'title-caption':
         slideElementFragment = createFragment('#slide-title-caption') as HTMLElement;
         slotElement = slideElementFragment.querySelector('[data-id=slide-title-caption-text]');
-        addLocationTracking(element, currentSlideId, slotElement);
+        addLocationTracking(element, currentSlideId, slotElement, space);
         renderSlideTextElement(element, slotElement);
         break;
       case 'text':
         slideElementFragment = createFragment('#slide-text-block') as HTMLElement;
         slotElement = slideElementFragment.querySelector('[data-id=slide-text-block-text]');
-        addLocationTracking(element, currentSlideId, slotElement);
+        addLocationTracking(element, currentSlideId, slotElement, space);
         renderSlideTextElement(element, slotElement);
         break;
       case 'img':
@@ -115,11 +115,11 @@ const renderSlide = (containerElement: HTMLElement, slideData: SlideData) => {
   });
 };
 
-const renderSelectedSlide = () => {
+const renderSelectedSlide = (space: Space) => {
   const selectedSlide = slideData.find((data) => data.selected);
   if (selectedSlide) {
     const selectedSlideContainer = document.querySelector('#slide-selected') as HTMLElement;
-    renderSlide(selectedSlideContainer, selectedSlide);
+    renderSlide(selectedSlideContainer, selectedSlide, space);
   }
 };
 

--- a/demo/app/components/feature-display.ts
+++ b/demo/app/components/feature-display.ts
@@ -2,6 +2,8 @@ import { SlideData, SlideImgElement, SlideTextElement } from '../data/default-sl
 import { slideData } from '../data/slide-data';
 import { createFragment } from '../utils/dom';
 import { gradients } from '../utils/gradients';
+import { getSpaceNameFromUrl } from '../utils/url';
+import { spaces as spacesInstance } from '../script';
 
 export const renderFeatureDisplay = () => {
   renderSlidePreviewMenu();
@@ -64,30 +66,51 @@ const renderSlideImgElement = (slideElement: SlideImgElement, htmlElement: HTMLI
   return htmlElement;
 };
 
+const addLocationTracking = async (element: SlideTextElement, currentSlideId: string, htmlElement: HTMLElement) => {
+  const spaces = await spacesInstance;
+  const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
+
+  htmlElement.addEventListener('click', () => {
+    console.log(space);
+    console.log(`slide-${currentSlideId}-element-${element.id}`);
+    space.locations.set(`slide-${currentSlideId}-element-${element.id}`);
+  });
+};
+
 const renderSlide = (containerElement: HTMLElement, slideData: SlideData) => {
+  const { id: currentSlideId } = slideData;
   containerElement.style.backgroundColor = '#FFF';
   slideData.elements.forEach((element) => {
     let slideElementFragment: HTMLElement;
+    let slotElement: HTMLElement | HTMLImageElement;
     switch (element.elementType) {
       case 'title':
         slideElementFragment = createFragment('#slide-title') as HTMLElement;
-        renderSlideTextElement(element, slideElementFragment.querySelector('[data-id=slide-title-text]'));
+        slotElement = slideElementFragment.querySelector('[data-id=slide-title-text]');
+        addLocationTracking(element, currentSlideId, slotElement);
+        renderSlideTextElement(element, slotElement);
         break;
       case 'title-caption':
         slideElementFragment = createFragment('#slide-title-caption') as HTMLElement;
-        renderSlideTextElement(element, slideElementFragment.querySelector('[data-id=slide-title-caption-text]'));
+        slotElement = slideElementFragment.querySelector('[data-id=slide-title-caption-text]');
+        addLocationTracking(element, currentSlideId, slotElement);
+        renderSlideTextElement(element, slotElement);
         break;
       case 'text':
         slideElementFragment = createFragment('#slide-text-block') as HTMLElement;
-        renderSlideTextElement(element, slideElementFragment.querySelector('[data-id=slide-text-block-text]'));
+        slotElement = slideElementFragment.querySelector('[data-id=slide-text-block-text]');
+        addLocationTracking(element, currentSlideId, slotElement);
+        renderSlideTextElement(element, slotElement);
         break;
       case 'img':
         slideElementFragment = createFragment('#slide-image') as HTMLElement;
-        renderSlideImgElement(element, slideElementFragment.querySelector('img[data-id=slide-image-placeholder]'));
+        slotElement = slideElementFragment.querySelector('[data-id=slide-image-placeholder]');
+        renderSlideImgElement(element, slotElement as HTMLImageElement);
         break;
       default:
         throw `Element Type not recognized`;
     }
+
     containerElement.appendChild(slideElementFragment);
   });
 };

--- a/demo/app/data/default-slide-data.ts
+++ b/demo/app/data/default-slide-data.ts
@@ -1,3 +1,7 @@
+import collaborativeDocumentUrl from '../assets/svg/collaborative-document.svg';
+import placeholderSlide1 from '../assets/svg/placeholder-slide-1.svg';
+import placeholderSlide2 from '../assets/svg/placeholder-slide-2.svg';
+import placeholderSlide3 from '../assets/svg/placeholder-slide-3.svg';
 import { nanoid } from 'nanoid';
 
 type SlideTextElementName = 'text' | 'title' | 'title-caption';
@@ -98,7 +102,7 @@ const defaultSelectedSlide = slideData(
       396,
       'Lauren',
     ),
-    slideImgElement('assets/svg/collaborative-document.svg', [543, 166]),
+    slideImgElement(collaborativeDocumentUrl, [543, 166]),
     slideTextElement('text')('2022', [952, 626]),
   ],
   IS_SELECTED,
@@ -106,9 +110,9 @@ const defaultSelectedSlide = slideData(
 
 // TODO: Define and render users associated with a particular slide
 export const defaultSlides = [
-  slideData('1', [slideImgElement('assets/svg/placeholder-slide-1.svg', [100, 160])]),
+  slideData('1', [slideImgElement(placeholderSlide1, [100, 160])]),
   defaultSelectedSlide,
-  slideData('3', [slideImgElement('assets/svg/placeholder-slide-2.svg', [100, 200])]),
-  slideData('4', [slideImgElement('assets/svg/placeholder-slide-3.svg', [200, 200])]),
-  slideData('5', [slideImgElement('assets/svg/placeholder-slide-2.svg', [100, 200])]),
+  slideData('3', [slideImgElement(placeholderSlide2, [100, 200])]),
+  slideData('4', [slideImgElement(placeholderSlide3, [200, 200])]),
+  slideData('5', [slideImgElement(placeholderSlide2, [100, 200])]),
 ];

--- a/demo/app/data/default-slide-data.ts
+++ b/demo/app/data/default-slide-data.ts
@@ -34,8 +34,6 @@ export type SlideImgElement = {
 
 export type SlideElement = SlideTextElement | SlideImgElement;
 
-// TODO: Define and render behaviour for elements that are `lockedBy` a user
-// TODO: Define and render behaviour for elements that have a `commentThreadId` started by a particular user
 const slideTextElement =
   (elementType: SlideTextElementName) =>
   (text: string, position: Position, width?: number, lockedBy?: string): SlideTextElement => ({
@@ -79,18 +77,7 @@ const defaultSelectedSlide = slideData(
   '2',
   [
     slideTextElement('title-caption')('HOW USERS READ', [64, 170]),
-    slideTextElement('title')(
-      `<div class="border-2 border-dashed border-[#FF007A] p-2 relative">
-				<div class="absolute w-11 h-11 rounded-full shadow-xl -right-11 -top-11 before:h-4 before:w-4 before:ml-1 before:mb-1 before:-rotate-12 before:content-[' '] before:inline-block before:bg-white before:rounded-1">
-					<div class="absolute w-10 h-10 top-0.5 left-0.5 rounded-full bg-purple-500 flex justify-center items-center">
-						<span class="font-medium text-base text-white">MH</span>
-					</div>
-				</div>
-				<span>Add graphics</span>
-			</div>
-			`,
-      [56, 197],
-    ),
+    slideTextElement('title')(`Add graphics`, [56, 197]),
     slideTextElement('text')(
       'No one likes boring text blocks on a website. And <span class="text-ably-avatar-stack-demo-slide-title-highlight font-semibold">images and icons</span> are the fastest way to get information.',
       [64, 288],

--- a/demo/app/data/default-slide-data.ts
+++ b/demo/app/data/default-slide-data.ts
@@ -1,3 +1,5 @@
+import { nanoid } from 'nanoid';
+
 type SlideTextElementName = 'text' | 'title' | 'title-caption';
 type SlideImgElementName = 'img';
 
@@ -6,6 +8,7 @@ const IS_SELECTED = true;
 type Position = [x: number, y: number];
 
 export type SlideTextElement = {
+  id: string;
   elementType: SlideTextElementName;
   text: string;
   position: Position;
@@ -15,6 +18,7 @@ export type SlideTextElement = {
 };
 
 export type SlideImgElement = {
+  id: string;
   elementType: SlideImgElementName;
   src: string;
   position: Position;
@@ -31,6 +35,7 @@ export type SlideElement = SlideTextElement | SlideImgElement;
 const slideTextElement =
   (elementType: SlideTextElementName) =>
   (text: string, position: Position, width?: number, lockedBy?: string): SlideTextElement => ({
+    id: nanoid(),
     elementType,
     text,
     position,
@@ -45,6 +50,7 @@ const slideImgElement = (
   caption?: string,
   lockedBy?: string,
 ): SlideImgElement => ({
+  id: nanoid(),
   elementType: 'img',
   src,
   position,
@@ -87,13 +93,7 @@ const defaultSelectedSlide = slideData(
       423,
     ),
     slideTextElement('text')(
-      `<div class="border-2 border-[#22BB5E] p-2 relative">
-				<span class="absolute w-2 h-2 bg-white border border-[#22BB5E] -top-1 -right-1"></span>
-				<span class="absolute w-2 h-2 bg-white border border-[#22BB5E] -bottom-1 -right-1"></span>
-				<span class="absolute w-2 h-2 bg-white border border-[#22BB5E] -bottom-1 -left-1"></span>
-				<span class="absolute -top-5 -left-0.5 py-0.5 px-2 rounded-t border-[#22BB5E] bg-[#22BB5E] text-white text-xs">Lauren</span>
-				But <span class="text-ably-avatar-stack-demo-slide-title-highlight font-semibold">don't overdo it</span>. If you can't explain for what purpose you put this line or icon, it's better to abandon it.
-			</div>`,
+      `But <span class="text-ably-avatar-stack-demo-slide-title-highlight font-semibold">don't overdo it</span>. If you can't explain for what purpose you put this line or icon, it's better to abandon it.`,
       [56, 416],
       396,
       'Lauren',

--- a/demo/app/data/default-slide-data.ts
+++ b/demo/app/data/default-slide-data.ts
@@ -36,8 +36,8 @@ export type SlideElement = SlideTextElement | SlideImgElement;
 
 const slideTextElement =
   (elementType: SlideTextElementName) =>
-  (text: string, position: Position, width?: number, lockedBy?: string): SlideTextElement => ({
-    id: nanoid(),
+  (id: string, text: string, position: Position, width?: number, lockedBy?: string): SlideTextElement => ({
+    id,
     elementType,
     text,
     position,
@@ -46,6 +46,7 @@ const slideTextElement =
   });
 
 const slideImgElement = (
+  id: string,
   src: string,
   position: Position,
   alt?: string,
@@ -76,30 +77,31 @@ const slideData = (id: string, elements = [], selected = !IS_SELECTED): SlideDat
 const defaultSelectedSlide = slideData(
   '2',
   [
-    slideTextElement('title-caption')('HOW USERS READ', [64, 170]),
-    slideTextElement('title')(`Add graphics`, [56, 197]),
+    slideTextElement('title-caption')('0', 'HOW USERS READ', [64, 170]),
+    slideTextElement('title')('1', `Add graphics`, [56, 197]),
     slideTextElement('text')(
+      '2',
       'No one likes boring text blocks on a website. And <span class="text-ably-avatar-stack-demo-slide-title-highlight font-semibold">images and icons</span> are the fastest way to get information.',
       [64, 288],
       423,
     ),
     slideTextElement('text')(
+      '3',
       `But <span class="text-ably-avatar-stack-demo-slide-title-highlight font-semibold">don't overdo it</span>. If you can't explain for what purpose you put this line or icon, it's better to abandon it.`,
       [56, 416],
       396,
       'Lauren',
     ),
-    slideImgElement(collaborativeDocumentUrl, [543, 166]),
-    slideTextElement('text')('2022', [952, 626]),
+    slideImgElement('4', collaborativeDocumentUrl, [543, 166]),
+    slideTextElement('text')('5', '2022', [952, 626]),
   ],
   IS_SELECTED,
 );
 
-// TODO: Define and render users associated with a particular slide
 export const defaultSlides = [
-  slideData('1', [slideImgElement(placeholderSlide1, [100, 160])]),
+  slideData('1', [slideImgElement('0', placeholderSlide1, [100, 160])]),
   defaultSelectedSlide,
-  slideData('3', [slideImgElement(placeholderSlide2, [100, 200])]),
-  slideData('4', [slideImgElement(placeholderSlide3, [200, 200])]),
-  slideData('5', [slideImgElement(placeholderSlide2, [100, 200])]),
+  slideData('3', [slideImgElement('0', placeholderSlide2, [100, 200])]),
+  slideData('4', [slideImgElement('0', placeholderSlide3, [200, 200])]),
+  slideData('5', [slideImgElement('0', placeholderSlide2, [100, 200])]),
 ];

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -552,6 +552,20 @@
       ></p>
     </template>
 
+    <template id="slide-text-block-selected">
+      <div class="border-2 border-[#22BB5E] p-2 relative">
+        <span
+          data-id="slide-text-block-selected-user"
+          class="absolute -top-5 -left-0.5 py-0.5 px-2 rounded-t border-[#22BB5E] bg-[#22BB5E] text-white text-xs"
+          >Lauren</span
+        >
+        <p
+          data-id="slide-text-block-text"
+          class="ably-avatar-stack-demo-slide-text text-[19px]"
+        ></p>
+      </div>
+    </template>
+
     <template id="slide-image">
       <figure>
         <img data-id="slide-image-placeholder" />

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -675,14 +675,5 @@
         </button>
       </li>
     </template>
-
-    <template id="avatar-seleceted-container">
-      <div class="border-2 border-dashed border-[#FF007A] p-2 relative">
-        <div
-          data-id="avatar-callout-container"
-          class="absolute w-11 h-11 rounded-full shadow-xl -right-11 -top-11 before:h-4 before:w-4 before:ml-1 before:mb-1 before:-rotate-12 before:content-[' '] before:inline-block before:bg-white before:rounded-1"
-        ></div>
-      </div>
-    </template>
   </body>
 </html>

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -156,7 +156,7 @@
 
       <div
         id="overlay"
-        class="absolute grid bg-black bg-opacity-25 w-full h-[calc(100%-80px)] select-none"
+        class="hidden absolute right-0 lg:grid bg-black bg-opacity-25 w-[354px] h-[calc(100%-80px)] select-none"
       >
         <aside
           id="coming-soon"
@@ -575,7 +575,7 @@
 
     <!-- COMMENTS -->
     <template id="comment-drawer">
-      <aside class="absolute w-[354] h-full bg-white right-0 top-0 p-8 hidden lg:block">
+      <aside class="absolute w-[354px] h-full bg-white right-0 top-0 p-8 hidden lg:block">
         <div class="flex flex-row justify-between">
           <h3 class="text-xl font-medium mb-14">Comments</h3>
           <svg

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -675,5 +675,14 @@
         </button>
       </li>
     </template>
+
+    <template id="avatar-seleceted-container">
+      <div class="border-2 border-dashed border-[#FF007A] p-2 relative">
+        <div
+          data-id="avatar-callout-container"
+          class="absolute w-11 h-11 rounded-full shadow-xl -right-11 -top-11 before:h-4 before:w-4 before:ml-1 before:mb-1 before:-rotate-12 before:content-[' '] before:inline-block before:bg-white before:rounded-1"
+        ></div>
+      </div>
+    </template>
   </body>
 </html>

--- a/demo/app/location-tracking/add-location-tracking.ts
+++ b/demo/app/location-tracking/add-location-tracking.ts
@@ -1,0 +1,59 @@
+import Space from '../../../src/Space';
+import { colors } from '../utils/colors';
+
+export const addLocationTracking = (id: string, htmlElement: HTMLElement, space: Space) => {
+  const selectedTracker = space.locations.createTracker((locationChange) => locationChange.currentLocation === id);
+  const unselectedTracker = space.locations.createTracker(
+    (locationChange) => locationChange.previousLocation === id && locationChange.currentLocation !== id,
+  );
+
+  const selectedClasses = ['outline-2', 'outline-dashed'];
+
+  selectedTracker.on((change) => {
+    const self = space.getSelf();
+
+    htmlElement.setAttribute(`data-client-${change.member.clientId}`, 'true');
+
+    if (change.member.clientId === self.clientId) {
+      htmlElement.classList.add(...selectedClasses, 'outline-blue-400');
+      return;
+    }
+
+    const members = space.getMembers();
+
+    const memberIndex = members
+      .filter((member) => member.clientId === change.member.clientId)
+      .findIndex((member) => member.clientId === change.member.clientId);
+    const color = colors[memberIndex % colors.length];
+    const outlineColor = `outline-${color[0]}-${color[1]}`;
+    htmlElement.classList.add(...selectedClasses, outlineColor);
+  });
+
+  unselectedTracker.on((change) => {
+    const self = space.getSelf();
+
+    htmlElement.removeAttribute(`data-client-${change.member.clientId}`);
+
+    const classesToRemove =
+      htmlElement.getAttributeNames().filter((name) => name.startsWith('data-client-')).length > 0
+        ? []
+        : selectedClasses;
+
+    if (change.member.clientId === self.clientId) {
+      htmlElement.classList.remove(...classesToRemove, 'outline-blue-400');
+      return;
+    }
+    const members = space.getMembers();
+    const memberIndex = members
+      .filter((member) => member.clientId === change.member.clientId)
+      .findIndex((member) => member.clientId === change.member.clientId);
+    const color = colors[memberIndex % colors.length];
+    const outlineColor = `outline-${color[0]}-${color[1]}`;
+
+    htmlElement.classList.remove(...classesToRemove, outlineColor);
+  });
+
+  htmlElement.addEventListener('click', () => {
+    space.locations.set(id);
+  });
+};

--- a/demo/app/location-tracking/add-location-tracking.ts
+++ b/demo/app/location-tracking/add-location-tracking.ts
@@ -1,5 +1,5 @@
 import Space from '../../../src/Space';
-import { colors } from '../utils/colors';
+import { locationChangeHandlers } from './location-change-handlers';
 
 export const addLocationTracking = (id: string, htmlElement: HTMLElement, space: Space) => {
   const selectedTracker = space.locations.createTracker((locationChange) => locationChange.currentLocation === id);
@@ -9,49 +9,11 @@ export const addLocationTracking = (id: string, htmlElement: HTMLElement, space:
 
   const selectedClasses = ['outline-2', 'outline-dashed'];
 
-  selectedTracker.on((change) => {
-    const self = space.getSelf();
+  const { selectLocation, deselectLocation } = locationChangeHandlers(htmlElement, selectedClasses, space);
 
-    htmlElement.setAttribute(`data-client-${change.member.clientId}`, 'true');
+  selectedTracker.on(selectLocation);
 
-    if (change.member.clientId === self.clientId) {
-      htmlElement.classList.add(...selectedClasses, 'outline-blue-400');
-      return;
-    }
-
-    const members = space.getMembers();
-
-    const memberIndex = members
-      .filter((member) => member.clientId === change.member.clientId)
-      .findIndex((member) => member.clientId === change.member.clientId);
-    const color = colors[memberIndex % colors.length];
-    const outlineColor = `outline-${color[0]}-${color[1]}`;
-    htmlElement.classList.add(...selectedClasses, outlineColor);
-  });
-
-  unselectedTracker.on((change) => {
-    const self = space.getSelf();
-
-    htmlElement.removeAttribute(`data-client-${change.member.clientId}`);
-
-    const classesToRemove =
-      htmlElement.getAttributeNames().filter((name) => name.startsWith('data-client-')).length > 0
-        ? []
-        : selectedClasses;
-
-    if (change.member.clientId === self.clientId) {
-      htmlElement.classList.remove(...classesToRemove, 'outline-blue-400');
-      return;
-    }
-    const members = space.getMembers();
-    const memberIndex = members
-      .filter((member) => member.clientId === change.member.clientId)
-      .findIndex((member) => member.clientId === change.member.clientId);
-    const color = colors[memberIndex % colors.length];
-    const outlineColor = `outline-${color[0]}-${color[1]}`;
-
-    htmlElement.classList.remove(...classesToRemove, outlineColor);
-  });
+  unselectedTracker.on(deselectLocation);
 
   htmlElement.addEventListener('click', () => {
     space.locations.set(id);

--- a/demo/app/location-tracking/location-change-handlers.ts
+++ b/demo/app/location-tracking/location-change-handlers.ts
@@ -1,0 +1,48 @@
+import { LocationChange } from '../../../src/Locations';
+import Space from '../../../src/Space';
+import { colors } from '../utils/colors';
+
+export const locationChangeHandlers = (htmlElement: HTMLElement, selectedClasses: string[], space: Space) => ({
+  selectLocation: (change: LocationChange<string>) => {
+    const self = space.getSelf();
+
+    htmlElement.setAttribute(`data-client-${change.member.clientId}`, 'true');
+
+    if (change.member.clientId === self.clientId) {
+      htmlElement.classList.add(...selectedClasses, 'outline-blue-400');
+      return;
+    }
+
+    const members = space.getMembers();
+    console.log(members);
+    const memberIndex = members
+      .filter((member) => member.clientId !== self.clientId)
+      .findIndex((member) => member.clientId === change.member.clientId);
+    const color = colors[memberIndex % colors.length];
+    const outlineColor = `outline-${color[0]}-${color[1]}`;
+    htmlElement.classList.add(...selectedClasses, outlineColor);
+  },
+  deselectLocation: (change: LocationChange<string>) => {
+    const self = space.getSelf();
+
+    htmlElement.removeAttribute(`data-client-${change.member.clientId}`);
+
+    const classesToRemove =
+      htmlElement.getAttributeNames().filter((name) => name.startsWith('data-client-')).length > 0
+        ? []
+        : selectedClasses;
+
+    if (change.member.clientId === self.clientId) {
+      htmlElement.classList.remove(...classesToRemove, 'outline-blue-400');
+      return;
+    }
+    const members = space.getMembers();
+    const memberIndex = members
+      .filter((member) => member.clientId !== self.clientId)
+      .findIndex((member) => member.clientId === change.member.clientId);
+    const color = colors[memberIndex % colors.length];
+    const outlineColor = `outline-${color[0]}-${color[1]}`;
+
+    htmlElement.classList.remove(...classesToRemove, outlineColor);
+  },
+});

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -7,6 +7,7 @@ import { getSpaceNameFromUrl } from './utils/url';
 import Spaces from '../../src/Spaces';
 import { renderAvatars, renderSelfAvatar } from './components/avatar-stack';
 import { renderFeatureDisplay } from './components/feature-display';
+import { SpaceMember } from '../../src/Space';
 
 const clientId = nanoid();
 
@@ -14,11 +15,11 @@ const ably = new Ably.Realtime.Promise({ authUrl: `/api/ably-token-request?clien
 
 const spaces = new Spaces(ably);
 
-export const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
+const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
 
-export const selfName = getRandomName();
+const selfName = getRandomName();
 
-const memberIsNotSelf = (member) => member.profileData.name !== selfName;
+const memberIsNotSelf = (member: SpaceMember) => member.clientId !== clientId;
 
 space.on('membersUpdate', (members) => {
   renderAvatars(members.filter(memberIsNotSelf));
@@ -26,7 +27,7 @@ space.on('membersUpdate', (members) => {
 
 renderSelfAvatar(selfName);
 renderFeatureDisplay(space);
-const initialMembers = await space.getMembers();
+const initialMembers = space.getMembers();
 renderAvatars(initialMembers.filter(memberIsNotSelf));
 
 space.enter({ name: selfName });

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -19,7 +19,6 @@ export const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 
 export const selfName = getRandomName();
 
 space.on('membersUpdate', (members) => {
-  console.log('firing');
   renderSelfAvatar(selfName);
   renderAvatars(members.filter((member) => member.profileData.name !== selfName));
   renderFeatureDisplay(space);

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -8,20 +8,7 @@ import Spaces from '../../src/Spaces';
 import { renderAvatars, renderSelfAvatar } from './components/avatar-stack';
 import { renderFeatureDisplay } from './components/feature-display';
 
-declare global {
-  interface Window {
-    AblySlidesDemo: {
-      clientId?: string;
-      selfName?: string;
-    };
-  }
-}
-
-if (!window.AblySlidesDemo) {
-  window.AblySlidesDemo = {};
-}
-
-const clientId = window.AblySlidesDemo.clientId ?? nanoid();
+const clientId = nanoid();
 
 const ably = new Ably.Realtime.Promise({ authUrl: `/api/ably-token-request?clientId=${clientId}`, clientId });
 
@@ -29,7 +16,7 @@ const spaces = new Spaces(ably);
 
 export const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
 
-export const selfName = window.AblySlidesDemo.selfName ?? getRandomName();
+export const selfName = getRandomName();
 
 space.on('membersUpdate', (members) => {
   console.log('firing');
@@ -42,6 +29,3 @@ renderSelfAvatar(selfName);
 renderFeatureDisplay(space);
 
 space.enter({ name: selfName });
-
-window.AblySlidesDemo.clientId = clientId;
-window.AblySlidesDemo.selfName = selfName;

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -18,13 +18,15 @@ export const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 
 
 export const selfName = getRandomName();
 
+const memberIsNotSelf = (member) => member.profileData.name !== selfName;
+
 space.on('membersUpdate', (members) => {
-  renderSelfAvatar(selfName);
-  renderAvatars(members.filter((member) => member.profileData.name !== selfName));
-  renderFeatureDisplay(space);
+  renderAvatars(members.filter(memberIsNotSelf));
 });
 
 renderSelfAvatar(selfName);
 renderFeatureDisplay(space);
+const initialMembers = await space.getMembers();
+renderAvatars(initialMembers.filter(memberIsNotSelf));
 
 space.enter({ name: selfName });

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -9,7 +9,7 @@ import Spaces from '../../src/Spaces';
 import { renderAvatars, renderSelfAvatar } from './components/avatar-stack';
 import { renderFeatureDisplay } from './components/feature-display';
 
-(async () => {
+export const spaces = (async () => {
   const clientId = nanoid();
   const ably = new Ably.Realtime.Promise({ authUrl: `/api/ably-token-request?clientId=${clientId}`, clientId });
 
@@ -17,13 +17,17 @@ import { renderFeatureDisplay } from './components/feature-display';
   const space = spaces.get(getSpaceNameFromUrl(), { offlineTimeout: 60_000 });
 
   const name = getRandomName();
+  console.log(name);
   const initialMembers = await space.enter({ name });
 
   space.on('membersUpdate', (members) => {
+    console.log(members);
     renderAvatars(members);
   });
 
   renderSelfAvatar(name);
   renderAvatars(initialMembers);
   renderFeatureDisplay();
+
+  return spaces;
 })();

--- a/demo/app/shims-svg.d.ts
+++ b/demo/app/shims-svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}

--- a/demo/app/utils/colors.ts
+++ b/demo/app/utils/colors.ts
@@ -1,0 +1,8 @@
+export const colors: [string, number][] = [
+  ['orange', 400],
+  ['pink', 400],
+  ['green', 400],
+  ['violet', 400],
+  ['rose', 400],
+  ['lime', 400],
+];

--- a/demo/app/utils/gradients.ts
+++ b/demo/app/utils/gradients.ts
@@ -1,8 +1,6 @@
-export const gradients = [
-  ['from-orange-400', 'to-orange-500'],
-  ['from-pink-400', 'to-pink-500'],
-  ['from-green-400', 'to-green-500'],
-  ['from-violet-400', 'to-violet-500'],
-  ['from-rose-400', 'to-rose-500'],
-  ['from-lime-400', 'to-lime-500'],
-];
+import { colors } from './colors';
+
+export const gradients = colors.map(([color, intensity]) => [
+  `from-${color}-${intensity}`,
+  `to-${color}-${intensity + 100}`,
+]);

--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -23,5 +23,10 @@ module.exports = {
       },
     },
   },
+  safelist: [
+    {
+      pattern: /(outline|bg|text|from|to)-(orange|pink|green|violet|rose|lime)-(400|500)/,
+    },
+  ],
   plugins: [],
 };

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -16,7 +16,7 @@ export type LocationChange<T> = {
 export default class Locations extends EventEmitter<LocationEventMap> {
   constructor(public space: Space, private channel: Types.RealtimeChannelPromise) {
     super();
-    this.channel.presence.subscribe(this.onPresenceUpdate);
+    this.channel.presence.subscribe(this.onPresenceUpdate.bind(this));
   }
 
   private onPresenceUpdate(message: Types.PresenceMessage) {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -179,8 +179,6 @@ class Space extends EventEmitter<{ membersUpdate: SpaceMember[] }> {
   }
 
   getSelf(): SpaceMember | undefined {
-    console.log(this.members);
-    console.log(this.clientId);
     return this.members.find((m) => m.clientId === this.clientId);
   }
 }

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -179,6 +179,8 @@ class Space extends EventEmitter<{ membersUpdate: SpaceMember[] }> {
   }
 
   getSelf(): SpaceMember | undefined {
+    console.log(this.members);
+    console.log(this.clientId);
     return this.members.find((m) => m.clientId === this.clientId);
   }
 }

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -152,8 +152,6 @@ class Space extends EventEmitter<{ membersUpdate: SpaceMember[] }> {
 
   private onPresenceUpdate(message: Types.PresenceMessage) {
     if (!message) return;
-    // By default, we only return data about other connected clients, not the whole set
-    if (message.clientId === this.clientId) return;
 
     this.updateLeavers(message);
     this.updateMembers(message);


### PR DESCRIPTION
This adds location tracking in its most basic/undifferentiated form to the slides demo (no locking, comments, sublocation tracking).

**A suggested starting point to test functionality**:
As usual:
* `npm run start` from the /demo folder as usual
* Visit the page at localhost:8888, copy the full URL as generated
* Paste the URL into an incognito tab
Then:
* In the normal window, click on a text element A in the main slide
* In the incognito window, click on a different text element B in the main slide
* Check that text element B renders with an orange border in the normal window, and that text element A renders with an orange border in the incognito window.
* Click text element A in the incognito window, then click text element A in the incognito window. Check that text element A still renders with an orange border in the incognito window (i.e. the selections haven't 'locked' together).