### PR TITLE
[MMB-88] Fix incorrect default library export

### DIFF
--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -1,6 +1,7 @@
 import { Types, Realtime } from 'ably';
 import SpaceOptions from './options/SpaceOptions.js';
 import Space from './Space.js';
+
 class Spaces {
   private spaces: Record<string, Space>;
   private channel: Types.RealtimeChannelPromise;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './Spaces.js';
+import Spaces from './Spaces.js';
+export default Spaces;


### PR DESCRIPTION
`export * from './file.js'` only re-exports named exports.