### PR TITLE
Add Live Cursors

### DIFF
--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -15,6 +15,7 @@ const mockPresence = {
 
 const mockChannel = {
   presence: mockPresence,
+  subscribe: ()=>{},
 };
 
 class MockRealtime {

--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -16,6 +16,7 @@ const mockPresence = {
 const mockChannel = {
   presence: mockPresence,
   subscribe: ()=>{},
+  publish: ()=>{}
 };
 
 class MockRealtime {

--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -7,6 +7,9 @@
 - [Space](#space)
 - [SpaceMember](#spacemember)
 - [Locations](#locations-1)
+- [Cursors](#cursors-1)
+- [Cursor](#cursor)
+- [CursorPosition](#cursorposition)
 
 ### Spaces
 
@@ -71,6 +74,9 @@ Gets the [SpaceMember](#spacemember) object which relates to the local client.
 
 #### locations
 Get the [Locations](#locations-1) object for this space.
+
+#### cursors
+Get the [Cursors](#cursors-1) object for this space.
 
 ### SpaceMember
 
@@ -138,3 +144,52 @@ Used for unsubscribing from a listener.
 
 #### members()
 Used to retrieve a list of members in the Space for whom the [locationUpdatePredicate](#locationupdatepredicatelocationupdate) would return `true` based on their current location.
+
+### Cursors
+
+#### get(name)
+Get a [Cursor](#cursor) with a specific name. Names are unique per space.
+
+| Property | Type   |
+|----------|--------|
+| name     | string |
+
+#### on(event, callback)
+Used for subscribing to all cursor updates. Currently, only one event is supported:
+
+##### positionsUpdate
+Fires when a cursors position is updated. The argument supplied is an object of one or more cursors by name and their respective cursor movements since the last update.
+
+| Property         | Type                                                |
+|------------------|-----------------------------------------------------|
+| positions        | Record<string, [CursorPosition](#cursorposition)[]> |
+
+### Cursor
+
+An individual cursor.
+
+#### setPosition(position)
+Set the position of this cursor. The position will be updated for each other member of the space via a Cursors [positionsUpdate](#positionsupdate) or Cursor [positionUpdate](#positionupdate).
+
+| Property | Type                              |
+|----------|-----------------------------------|
+| position | [CursorPosition](#cursorposition) |
+
+#### on(event, callback)
+Used for subscribing to a specific cursors updates. Currently, only one event is supported:
+
+##### positionUpdate
+Fires when this cursors location is updated. Contains an array of cursor positions since the last update.
+
+| Property  | Type                                |
+|-----------|-------------------------------------|
+| positions | [CursorPosition](#cursorposition)[] |
+
+
+### CursorPosition
+Represents the position of a cursor.
+
+| Property | Type   |
+|----------|--------|
+| x        | number |
+| y        | number |

--- a/src/Cursor.ts
+++ b/src/Cursor.ts
@@ -1,9 +1,7 @@
 import EventEmitter from './utilities/EventEmitter';
-import Cursors, { CursorPosition } from './Cursors';
+import { CursorPosition } from './Cursors';
 import CursorBatching from './CursorBatching';
 import Space from './Space';
-import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
-import { Types } from 'ably';
 
 type CursorEventMap = { positionUpdate: CursorPosition[] };
 

--- a/src/Cursor.ts
+++ b/src/Cursor.ts
@@ -1,12 +1,11 @@
 import EventEmitter from './utilities/EventEmitter';
 import { CursorPosition } from './Cursors';
 import CursorBatching from './CursorBatching';
-import Space from './Space';
 
 type CursorEventMap = { positionUpdate: CursorPosition[] };
 
 export default class Cursor extends EventEmitter<CursorEventMap> {
-  constructor(private name: string, private cursorBatching: CursorBatching, private space: Space) {
+  constructor(private name: string, private cursorBatching: CursorBatching) {
     super();
   }
 

--- a/src/Cursor.ts
+++ b/src/Cursor.ts
@@ -1,0 +1,18 @@
+import EventEmitter from './utilities/EventEmitter';
+import Cursors, { CursorPosition } from './Cursors';
+import CursorBatching from './CursorBatching';
+import Space from './Space';
+import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
+import { Types } from 'ably';
+
+type CursorEventMap = { positionUpdate: CursorPosition[] };
+
+export default class Cursor extends EventEmitter<CursorEventMap> {
+  constructor(private name: string, private cursorBatching: CursorBatching, private space: Space) {
+    super();
+  }
+
+  setPosition(position: CursorPosition) {
+    this.cursorBatching.pushCursorPosition(this.name, position);
+  }
+}

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -22,7 +22,7 @@ export default class CursorBatching {
     this.channel.presence.enter();
   }
 
-  async onPresenceUpdate(message: Types.PresenceMessage) {
+  async onPresenceUpdate() {
     const members = await this.channel.presence.get();
     console.log(members);
     this.shouldSend = members.length > 1;
@@ -44,7 +44,7 @@ export default class CursorBatching {
     }
   }
 
-  private async batchCursors() {
+  async batchCursors() {
     if (!this.hasMovements) {
       this.isRunning = false;
       return;

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,13 +1,11 @@
 import Cursors, { CursorPosition } from './Cursors';
-import Space from './Space';
 import { Types } from 'ably';
-import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
 
 const BATCH_TIME_UPDATE = 100;
 
 export default class CursorBatching {
   outgoingBuffer: Record<string, CursorPosition[]> = {};
-  readonly channel: Types.RealtimeChannelPromise;
+
   batchTime: number = 100;
   // Set to `true` when the buffer is actively being emptied
   isRunning: boolean = false;
@@ -16,15 +14,13 @@ export default class CursorBatching {
   // Set to `true` if there is more than one user listening to cursors
   shouldSend: boolean = false;
 
-  constructor(readonly cursors: Cursors, readonly space: Space) {
-    this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
+  constructor(readonly cursors: Cursors, readonly channel: Types.RealtimeChannelPromise) {
     this.channel.presence.subscribe(this.onPresenceUpdate.bind(this));
     this.channel.presence.enter();
   }
 
   async onPresenceUpdate() {
     const members = await this.channel.presence.get();
-    console.log(members);
     this.shouldSend = members.length > 1;
     this.batchTime = (members.length - 1) * BATCH_TIME_UPDATE;
   }

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,0 +1,59 @@
+import Cursors, { CursorPosition } from './Cursors';
+import Space from './Space';
+import { Types } from 'ably';
+import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
+
+const BATCH_TIME_UPDATE = 100;
+
+export default class CursorBatching {
+  outgoingBuffer: Record<string, CursorPosition[]> = {};
+  readonly channel: Types.RealtimeChannelPromise;
+  batchTime: number = 100;
+  // Set to `true` when the buffer is actively being emptied
+  isRunning: boolean = false;
+  // Set to `true` when a cursor position is in the buffer
+  hasMovements: boolean = false;
+  // Set to `true` if there is more than one user listening to cursors
+  shouldSend: boolean = false;
+
+  constructor(readonly cursors: Cursors, readonly space: Space) {
+    this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
+    this.channel.presence.subscribe(this.onPresenceUpdate.bind(this));
+    this.channel.presence.enter();
+  }
+
+  async onPresenceUpdate(message: Types.PresenceMessage) {
+    const members = await this.channel.presence.get();
+    console.log(members);
+    this.shouldSend = members.length > 1;
+    this.batchTime = (members.length - 1) * BATCH_TIME_UPDATE;
+  }
+
+  pushCursorPosition(name: string, pos: CursorPosition) {
+    // Ignore the cursor update if there is no one listening
+    if (!this.shouldSend) return;
+    this.hasMovements = true;
+    if (this.outgoingBuffer[name]) {
+      this.outgoingBuffer[name].push(pos);
+    } else {
+      this.outgoingBuffer[name] = [pos];
+    }
+    if (!this.isRunning) {
+      this.batchCursors();
+      this.isRunning = true;
+    }
+  }
+
+  private async batchCursors() {
+    if (!this.hasMovements) {
+      this.isRunning = false;
+      return;
+    }
+    // Must be copied here to avoid a race condition where the buffer is cleared before the publish happens
+    const bufferCopy = { ...this.outgoingBuffer };
+    this.outgoingBuffer = {};
+    this.hasMovements = false;
+    await this.channel.publish('cursors', bufferCopy);
+    setTimeout(this.batchCursors, this.batchTime);
+  }
+}

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -1,0 +1,98 @@
+import { it, describe, expect, vi, expectTypeOf, beforeEach, vitest } from 'vitest';
+import { Realtime, Types } from 'ably/promises';
+import Space, { SpaceMember } from './Space.js';
+import { createPresenceMessage } from './utilities/test/fakes.js';
+import Cursor from './Cursor';
+import CursorBatching from './CursorBatching';
+
+interface CursorsTestContext {
+  client: Types.RealtimePromise;
+  space: Space;
+  batching: CursorBatching;
+}
+
+vi.mock('ably/promises');
+
+describe('Cursors (mockClient)', () => {
+  beforeEach<CursorsTestContext>((context) => {
+    const client = new Realtime({});
+    context.client = client;
+    context.space = new Space('test', client);
+    context.batching = context.space.cursors['cursorBatching'];
+  });
+
+  describe('get', () => {
+    it<CursorsTestContext>('creates a cursor and returns it', ({ space }) => {
+      expectTypeOf(space.cursors.get('cursor1')).toMatchTypeOf<Cursor>();
+    });
+
+    it<CursorsTestContext>('returns an existing cursor', ({ space }) => {
+      const cursor1 = space.cursors.get('cursor1');
+      const cursor2 = space.cursors.get('cursor2');
+      expect(cursor1).not.toEqual(cursor2);
+      expect(space.cursors.get('cursor1')).toEqual(cursor1);
+    });
+
+    it<CursorsTestContext>('emits a positionsUpdate event', ({ space }) => {
+      const fakeMessage = { data: { cursor1: [], cursor2: [] } };
+      const spy = vitest.fn();
+      space.cursors.on('positionsUpdate', spy);
+      space.cursors['onIncomingCursorMovement'](fakeMessage as Types.Message);
+      expect(spy).toHaveBeenCalledWith(fakeMessage.data);
+    });
+
+    it<CursorsTestContext>('emits positionUpdate for a specific cursor event', ({ space }) => {
+      const fakeMessage = { data: { cursor1: [{ x: 1, y: 1 }] } };
+      const spy = vitest.fn();
+      space.cursors.get('cursor1').on('positionUpdate', spy);
+      space.cursors['onIncomingCursorMovement'](fakeMessage as Types.Message);
+      expect(spy).toHaveBeenCalledWith(fakeMessage.data.cursor1);
+    });
+  });
+
+  describe('cursorBatching', () => {
+    it<CursorsTestContext>('shouldSend is set to false when there is one client present', async ({ batching }) => {
+      const presence = batching.channel.presence;
+      vi.spyOn(presence, 'get').mockImplementation(createPresenceCount(1));
+      await batching.onPresenceUpdate({} as Types.PresenceMessage);
+      expect(batching.shouldSend).toBeFalsy();
+    });
+
+    it<CursorsTestContext>('shouldSend is set to true when there is more than one client present', async ({
+      batching,
+    }) => {
+      vi.spyOn(batching.channel.presence, 'get').mockImplementation(createPresenceCount(2));
+      await batching.onPresenceUpdate({} as Types.PresenceMessage);
+      expect(batching.shouldSend).toBeTruthy();
+      expect(batching.batchTime).toEqual(100);
+    });
+
+    it<CursorsTestContext>('batchTime is updated when multiple people are present', async ({ batching }) => {
+      vi.spyOn(batching.channel.presence, 'get').mockImplementation(createPresenceCount(2));
+      await batching.onPresenceUpdate({} as Types.PresenceMessage);
+      expect(batching.batchTime).toEqual(100);
+    });
+
+    it<CursorsTestContext>('pushCursorPosition should ignore cursor updates if shouldSend is false', async ({
+      batching,
+    }) => {
+      batching.shouldSend = false;
+      expect(batching.hasMovements).toBeFalsy();
+      batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
+      expect(batching.hasMovements).toBeFalsy();
+    });
+
+    it<CursorsTestContext>('pushCursorPosition sets hasMovements to true', async ({ batching }) => {
+      // Set isRunning to true to avoid starting the loop here
+      batching.isRunning = true;
+      batching.shouldSend = true;
+      expect(batching.hasMovements).toBeFalsy();
+      batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
+      expect(batching.hasMovements).toBeTruthy();
+    });
+  });
+});
+
+function createPresenceCount(length: number) {
+  return async () => Array.from({ length }, (_, i) => createPresenceMessage('enter', { clientId: '' + i }));
+}

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -16,9 +16,9 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
 
   constructor(private space: Space) {
     super();
-    this.cursorBatching = new CursorBatching(this, space);
     this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
     this.channel.subscribe('cursors', this.onIncomingCursorMovement.bind(this));
+    this.cursorBatching = new CursorBatching(this, this.channel);
   }
 
   private onIncomingCursorMovement(message: Types.Message) {
@@ -34,7 +34,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
 
   get(name: string): Cursor {
     if (!this.cursors[name]) {
-      this.cursors[name] = new Cursor(name, this.cursorBatching, this.space);
+      this.cursors[name] = new Cursor(name, this.cursorBatching);
     }
     return this.cursors[name];
   }

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -1,0 +1,41 @@
+import Space from './Space';
+import Cursor from './Cursor';
+import CursorBatching from './CursorBatching';
+import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
+import { Types } from 'ably';
+import EventEmitter from './utilities/EventEmitter';
+
+type CursorsEventMap = { positionsUpdate: Record<string, CursorPosition[]> };
+
+export type CursorPosition = { x: number; y: number };
+export default class Cursors extends EventEmitter<CursorsEventMap> {
+  private readonly cursorBatching: CursorBatching;
+
+  private cursors: Record<string, Cursor> = {};
+  private channel: Types.RealtimeChannelPromise;
+
+  constructor(private space: Space) {
+    super();
+    this.cursorBatching = new CursorBatching(this, space);
+    this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
+    this.channel.subscribe('cursors', this.onIncomingCursorMovement.bind(this));
+  }
+
+  private onIncomingCursorMovement(message: Types.Message) {
+    const cursorData: Record<string, CursorPosition[]> = message.data;
+    this.emit('positionsUpdate', cursorData);
+    for (let cursorName in cursorData) {
+      const cursor = this.cursors[cursorName];
+      if (!cursor) continue;
+      const cursorPositions = cursorData[cursorName];
+      cursor.emit('positionUpdate', cursorPositions);
+    }
+  }
+
+  get(name: string): Cursor {
+    if (!this.cursors[name]) {
+      this.cursors[name] = new Cursor(name, this.cursorBatching, this.space);
+    }
+    return this.cursors[name];
+  }
+}

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -4,6 +4,7 @@ import { Realtime, Types } from 'ably/promises';
 import Space, { SpaceMember } from './Space.js';
 import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes.js';
 import Locations from './Locations.js';
+import Cursors from './Cursors';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
@@ -368,6 +369,12 @@ describe('Space (mockClient)', () => {
   describe('locations', () => {
     it<SpaceTestContext>('returns a Locations object', ({ space }) => {
       expect(space.locations).toBeInstanceOf(Locations);
+    });
+  });
+
+  describe('cursors', () => {
+    it<SpaceTestContext>('returns a Cursors object', ({ space }) => {
+      expect(space.cursors).toBeInstanceOf(Cursors);
     });
   });
 });

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -105,7 +105,7 @@ describe('Space (mockClient)', () => {
       const spy = vi.spyOn(presence, 'subscribe');
       new Space('test', client);
       // Called by Space instantiation and by Locations instantiation
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
     });
 
     it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -3,9 +3,10 @@ import { Types } from 'ably';
 import SpaceOptions from './options/SpaceOptions.js';
 import EventEmitter from './utilities/EventEmitter.js';
 import Locations from './Locations.js';
+import Cursors from './Cursors';
 
 // Unique prefix to avoid conflicts with channels
-const SPACE_CHANNEL_PREFIX = '_ably_space_';
+import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
 
 export type SpaceMember = {
   clientId: string;
@@ -36,9 +37,10 @@ class Space extends EventEmitter<{ membersUpdate: SpaceMember[] }> {
   private leavers: SpaceLeaver[];
   private options: SpaceOptions;
 
-  locations: Locations;
+  readonly locations: Locations;
+  readonly cursors: Cursors;
 
-  constructor(private name: string, private client: Types.RealtimePromise, options?: SpaceOptions) {
+  constructor(readonly name: string, readonly client: Types.RealtimePromise, options?: SpaceOptions) {
     super();
     this.options = { ...SPACE_OPTIONS_DEFAULTS, ...options };
     this.clientId = this.client.auth.clientId;
@@ -47,6 +49,7 @@ class Space extends EventEmitter<{ membersUpdate: SpaceMember[] }> {
     this.onPresenceUpdate = this.onPresenceUpdate.bind(this);
     this.setChannel(this.name);
     this.locations = new Locations(this, this.channel);
+    this.cursors = new Cursors(this);
   }
 
   private setChannel(rootName: string) {

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -41,7 +41,7 @@ describe('Spaces', () => {
     const spaces = new Spaces(client);
     const space = spaces.get('test');
 
-    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledTimes(3);
     expect(spy).toHaveBeenCalledWith('_ably_space_test');
     // Note: This is matching the class type. This is not a TypeScript type.
     expectTypeOf(space).toMatchTypeOf<Space>();

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -41,7 +41,7 @@ describe('Spaces', () => {
     const spaces = new Spaces(client);
     const space = spaces.get('test');
 
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith('_ably_space_test');
     // Note: This is matching the class type. This is not a TypeScript type.
     expectTypeOf(space).toMatchTypeOf<Space>();

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -1,0 +1,1 @@
+export const SPACE_CHANNEL_PREFIX = '_ably_space_';


### PR DESCRIPTION
Add Live Cursor functionality to Spaces.

A cursor is retrievable by name from the Cursors class, and represents a point on a 2D plane.

The Cursors class emits one kind of event, a `positionsUpdate`, which can be subscribed to via. the cursor `on` method.

A cursor's position can be updated and will be shared with other users.

Sharing a cursor's position with other users is managed by the CursorBatching class, which collects frequent cursor updates to be shared as a batch.