### PR TITLE
[MMB-64] Set additional data on a cursor

### DIFF
--- a/src/Cursor.ts
+++ b/src/Cursor.ts
@@ -1,19 +1,26 @@
 import EventEmitter from './utilities/EventEmitter';
-import { CursorData, CursorPosition } from './Cursors';
+import { CursorUpdate } from './Cursors';
 import CursorBatching from './CursorBatching';
 
-type CursorEventMap = { positionUpdate: CursorPosition[]; cursorDataUpdate: CursorData[] };
+type CursorEventMap = { cursorUpdate: CursorUpdate[] };
 
+/** Class that enables updating and emitting events for a specific cursor. */
 export default class Cursor extends EventEmitter<CursorEventMap> {
+  /**
+   * @param {string} name
+   * @param {CursorBatching} cursorBatching
+   */
   constructor(private name: string, private cursorBatching: CursorBatching) {
     super();
   }
 
-  setData(data: CursorData) {
-    this.cursorBatching.pushCursorData(this.name, data);
-  }
-
-  setPosition(position: CursorPosition) {
-    this.cursorBatching.pushCursorPosition(this.name, position);
+  /**
+   * Schedules a cursor update event to be sent that will cause the following events to fire
+   *
+   * @param {CursorUpdate} cursor
+   * @return {void}
+   */
+  set(cursor: CursorUpdate): void {
+    this.cursorBatching.pushCursorPosition(this.name, cursor);
   }
 }

--- a/src/Cursor.ts
+++ b/src/Cursor.ts
@@ -1,12 +1,16 @@
 import EventEmitter from './utilities/EventEmitter';
-import { CursorPosition } from './Cursors';
+import { CursorData, CursorPosition } from './Cursors';
 import CursorBatching from './CursorBatching';
 
-type CursorEventMap = { positionUpdate: CursorPosition[] };
+type CursorEventMap = { positionUpdate: CursorPosition[]; cursorDataUpdate: CursorData[] };
 
 export default class Cursor extends EventEmitter<CursorEventMap> {
   constructor(private name: string, private cursorBatching: CursorBatching) {
     super();
+  }
+
+  setData(data: CursorData) {
+    this.cursorBatching.pushCursorData(this.name, data);
   }
 
   setPosition(position: CursorPosition) {

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,16 +1,37 @@
-import Cursors, { CursorPosition } from './Cursors';
+import Cursors, { CursorData, CursorPosition } from './Cursors';
 import { Types } from 'ably';
 
 const BATCH_TIME_UPDATE = 100;
 
+const CURSOR_POSITION_CHANNEL = 'cursorPosition';
+const CURSOR_DATA_CHANNEL = 'cursorDataUpdate';
+
+type OutgoingBuffers = {
+  movement: Record<string, CursorPosition[]>;
+  data: Record<string, CursorData[]>;
+};
+
+type AreBuffersActive = {
+  movement: boolean;
+  data: boolean;
+};
+
 export default class CursorBatching {
-  outgoingBuffer: Record<string, CursorPosition[]> = {};
+  outgoingBuffers: OutgoingBuffers = {
+    movement: {},
+    data: {},
+  };
+
+  has: AreBuffersActive = {
+    // Set to `true` when a cursor position is in the buffer
+    movement: false,
+    // Set to 'true' when an update to cursor data is in the buffer
+    data: false,
+  };
 
   batchTime: number = 100;
   // Set to `true` when the buffer is actively being emptied
   isRunning: boolean = false;
-  // Set to `true` when a cursor position is in the buffer
-  hasMovements: boolean = false;
   // Set to `true` if there is more than one user listening to cursors
   shouldSend: boolean = false;
 
@@ -19,37 +40,57 @@ export default class CursorBatching {
     this.channel.presence.enter();
   }
 
-  async onPresenceUpdate() {
+  pushCursorPosition(name: string, pos: CursorPosition) {
+    // Ignore the cursor update if there is no one listening
+    if (!this.shouldSend) return;
+    this.has.movement = true;
+    this.pushToBuffer<CursorPosition>('movement', name, pos);
+    this.publishFromBuffer('movement', CURSOR_POSITION_CHANNEL);
+  }
+
+  pushCursorData(name: string, data: CursorData) {
+    // Ignore the cursor update if there is no one listening
+    if (!this.shouldSend) return;
+    this.has.data = true;
+    this.pushToBuffer<CursorData>('data', name, data);
+    this.publishFromBuffer('data', CURSOR_DATA_CHANNEL);
+  }
+
+  private async onPresenceUpdate() {
     const members = await this.channel.presence.get();
     this.shouldSend = members.length > 1;
     this.batchTime = (members.length - 1) * BATCH_TIME_UPDATE;
   }
 
-  pushCursorPosition(name: string, pos: CursorPosition) {
-    // Ignore the cursor update if there is no one listening
-    if (!this.shouldSend) return;
-    this.hasMovements = true;
-    if (this.outgoingBuffer[name]) {
-      this.outgoingBuffer[name].push(pos);
+  private pushToBuffer<T>(bufferName: string, key: string, value: T) {
+    const buffer: Record<string, T[]> = this.outgoingBuffers[bufferName];
+    if (buffer[key]) {
+      buffer[key].push(value);
     } else {
-      this.outgoingBuffer[name] = [pos];
-    }
-    if (!this.isRunning) {
-      this.batchCursors();
-      this.isRunning = true;
+      (buffer[key] as T[]) = [value];
     }
   }
 
-  async batchCursors() {
-    if (!this.hasMovements) {
+  private async publishFromBuffer(bufferName: keyof OutgoingBuffers, channelName: string) {
+    if (!this.isRunning) {
+      this.isRunning = true;
+      await this.batchToChannel(bufferName, channelName);
+    }
+  }
+
+  private async batchToChannel(bufferName: keyof OutgoingBuffers, channelName: string) {
+    if (!this.has.movement) {
       this.isRunning = false;
       return;
     }
     // Must be copied here to avoid a race condition where the buffer is cleared before the publish happens
-    const bufferCopy = { ...this.outgoingBuffer };
-    this.outgoingBuffer = {};
-    this.hasMovements = false;
-    await this.channel.publish('cursors', bufferCopy);
-    setTimeout(this.batchCursors, this.batchTime);
+    const bufferCopy = { ...this.outgoingBuffers[bufferName] };
+    await this.channel.publish(channelName, bufferCopy);
+    setTimeout(() => this.batchToChannel(bufferName, channelName), this.batchTime);
+    this.outgoingBuffers[bufferName] = {};
+    this.has[bufferName] = false;
+    this.isRunning = true;
   }
 }
+
+export { CURSOR_DATA_CHANNEL, CURSOR_POSITION_CHANNEL };

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,6 +1,6 @@
 import Cursors, { CursorUpdate } from './Cursors';
 import { Types } from 'ably';
-import { CURSOR_EVENT } from './utilities/Constants';
+import { CURSOR_UPDATE } from './utilities/Constants';
 
 const BATCH_TIME_UPDATE = 100;
 
@@ -28,7 +28,7 @@ export default class CursorBatching {
     if (!this.shouldSend) return;
     this.hasMovement = true;
     this.pushToBuffer(name, cursor);
-    this.publishFromBuffer(CURSOR_EVENT);
+    this.publishFromBuffer(CURSOR_UPDATE);
   }
 
   private async onPresenceUpdate() {

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,57 +1,34 @@
-import Cursors, { CursorData, CursorPosition } from './Cursors';
+import Cursors, { CursorUpdate } from './Cursors';
 import { Types } from 'ably';
-import { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT } from './utilities/Constants';
+import { CURSOR_EVENT } from './utilities/Constants';
 
 const BATCH_TIME_UPDATE = 100;
 
-type OutgoingBuffers = {
-  movement: Record<string, CursorPosition[]>;
-  data: Record<string, CursorData[]>;
-};
-
-type AreBuffersActive = {
-  movement: boolean;
-  data: boolean;
-};
+type OutgoingBuffer = Record<string, CursorUpdate[]>;
 
 export default class CursorBatching {
-  outgoingBuffers: OutgoingBuffers = {
-    movement: {},
-    data: {},
-  };
-
-  has: AreBuffersActive = {
-    // Set to `true` when a cursor position is in the buffer
-    movement: false,
-    // Set to 'true' when an update to cursor data is in the buffer
-    data: false,
-  };
+  outgoingBuffers: OutgoingBuffer = {};
 
   batchTime: number = 100;
-  // Set to `true` when the buffer is actively being emptied
+
+  hasMovement = false;
+  // Set to `true` when a cursor position is in the buffer
   isRunning: boolean = false;
-  // Set to `true` if there is more than one user listening to cursors
+  // Set to `true` when the buffer is actively being emptied
   shouldSend: boolean = false;
+  // Set to `true` if there is more than one user listening to cursors
 
   constructor(readonly cursors: Cursors, readonly channel: Types.RealtimeChannelPromise) {
     this.channel.presence.subscribe(this.onPresenceUpdate.bind(this));
     this.channel.presence.enter();
   }
 
-  pushCursorPosition(name: string, pos: CursorPosition) {
+  pushCursorPosition(name: string, cursor: CursorUpdate) {
     // Ignore the cursor update if there is no one listening
     if (!this.shouldSend) return;
-    this.has.movement = true;
-    this.pushToBuffer<CursorPosition>('movement', name, pos);
-    this.publishFromBuffer('movement', CURSOR_POSITION_EVENT);
-  }
-
-  pushCursorData(name: string, data: CursorData) {
-    // Ignore the cursor update if there is no one listening
-    if (!this.shouldSend) return;
-    this.has.data = true;
-    this.pushToBuffer<CursorData>('data', name, data);
-    this.publishFromBuffer('data', CURSOR_DATA_EVENT);
+    this.hasMovement = true;
+    this.pushToBuffer(name, cursor);
+    this.publishFromBuffer(CURSOR_EVENT);
   }
 
   private async onPresenceUpdate() {
@@ -60,33 +37,32 @@ export default class CursorBatching {
     this.batchTime = (members.length - 1) * BATCH_TIME_UPDATE;
   }
 
-  private pushToBuffer<T>(bufferName: string, key: string, value: T) {
-    const buffer: Record<string, T[]> = this.outgoingBuffers[bufferName];
-    if (buffer[key]) {
-      buffer[key].push(value);
+  private pushToBuffer(key: string, value: CursorUpdate) {
+    if (this.outgoingBuffers[key]) {
+      this.outgoingBuffers[key].push(value);
     } else {
-      (buffer[key] as T[]) = [value];
+      this.outgoingBuffers[key] = [value];
     }
   }
 
-  private async publishFromBuffer(bufferName: keyof OutgoingBuffers, eventName: string) {
+  private async publishFromBuffer(eventName: string) {
     if (!this.isRunning) {
       this.isRunning = true;
-      await this.batchToChannel(bufferName, eventName);
+      await this.batchToChannel(eventName);
     }
   }
 
-  private async batchToChannel(bufferName: keyof OutgoingBuffers, eventName: string) {
-    if (!this.has[bufferName]) {
+  private async batchToChannel(eventName: string) {
+    if (!this.hasMovement) {
       this.isRunning = false;
       return;
     }
     // Must be copied here to avoid a race condition where the buffer is cleared before the publish happens
-    const bufferCopy = { ...this.outgoingBuffers[bufferName] };
+    const bufferCopy = { ...this.outgoingBuffers };
     await this.channel.publish(eventName, bufferCopy);
-    setTimeout(() => this.batchToChannel(bufferName, eventName), this.batchTime);
-    this.outgoingBuffers[bufferName] = {};
-    this.has[bufferName] = false;
+    setTimeout(() => this.batchToChannel(eventName), this.batchTime);
+    this.outgoingBuffers = {};
+    this.hasMovement = false;
     this.isRunning = true;
   }
 }

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,10 +1,8 @@
 import Cursors, { CursorData, CursorPosition } from './Cursors';
 import { Types } from 'ably';
+import { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT } from './utilities/Constants';
 
 const BATCH_TIME_UPDATE = 100;
-
-const CURSOR_POSITION_EVENT = 'cursorPosition';
-const CURSOR_DATA_EVENT = 'cursorDataUpdate';
 
 type OutgoingBuffers = {
   movement: Record<string, CursorPosition[]>;
@@ -79,7 +77,7 @@ export default class CursorBatching {
   }
 
   private async batchToChannel(bufferName: keyof OutgoingBuffers, eventName: string) {
-    if (!this.has.movement) {
+    if (!this.has[bufferName]) {
       this.isRunning = false;
       return;
     }
@@ -92,5 +90,3 @@ export default class CursorBatching {
     this.isRunning = true;
   }
 }
-
-export { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT };

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -4,7 +4,7 @@ import Space from './Space.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
-import { CURSOR_EVENT } from './utilities/Constants.js';
+import { CURSOR_UPDATE } from './utilities/Constants.js';
 
 interface CursorsTestContext {
   client: Types.RealtimePromise;
@@ -141,7 +141,7 @@ describe('Cursors (mockClient)', () => {
         batching.hasMovement = false;
         batching.isRunning = true;
         const spy = vi.spyOn(space.cursors['channel'], 'publish');
-        await batching.batchToChannel('movement', CURSOR_EVENT);
+        await batching.batchToChannel('movement', CURSOR_UPDATE);
         expect(batching.isRunning).toBeFalsy();
         expect(spy).not.toHaveBeenCalled();
       });
@@ -152,22 +152,22 @@ describe('Cursors (mockClient)', () => {
         batching.hasMovement = true;
         batching.outgoingBuffers = { cursor1: [{ position: { x: 1, y: 1 }, data: {} }] };
         const spy = vi.spyOn(space.cursors['channel'], 'publish');
-        await batching.batchToChannel(CURSOR_EVENT);
-        expect(spy).toHaveBeenCalledWith(CURSOR_EVENT, { cursor1: [{ position: { x: 1, y: 1 }, data: {} }] });
+        await batching.batchToChannel(CURSOR_UPDATE);
+        expect(spy).toHaveBeenCalledWith(CURSOR_UPDATE, { cursor1: [{ position: { x: 1, y: 1 }, data: {} }] });
       });
 
       it<CursorsTestContext>('should clear the buffer', async (context) => {
         const batching = context.batching as any;
         batching.hasMovement = true;
         batching.outgoingBuffers = { cursor1: [{ position: { x: 1, y: 1 }, data: {} }] };
-        await batching.batchToChannel(CURSOR_EVENT);
+        await batching.batchToChannel(CURSOR_UPDATE);
         expect(batching.outgoingBuffers).toEqual({});
       });
 
       it<CursorsTestContext>('should set hasMovements to false', async (context) => {
         const batching = context.batching as any;
         batching.hasMovement = true;
-        await batching.batchToChannel(CURSOR_EVENT);
+        await batching.batchToChannel(CURSOR_UPDATE);
         expect(batching.hasMovement).toBeFalsy();
       });
     });

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -3,7 +3,8 @@ import { Realtime, Types } from 'ably/promises';
 import Space from './Space.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 import Cursor from './Cursor';
-import CursorBatching, { CURSOR_POSITION_EVENT } from './CursorBatching';
+import CursorBatching from './CursorBatching';
+import { CURSOR_POSITION_EVENT } from './utilities/Constants.js';
 
 interface CursorsTestContext {
   client: Types.RealtimePromise;

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -90,14 +90,14 @@ describe('Cursors (mockClient)', () => {
         expect(batching.has.movement).toBeFalsy();
       });
 
-      it<CursorsTestContext>('sets hasMovements to true', (context) => {
+      it<CursorsTestContext>('sets has.movements to true', (context) => {
         const batching = context.batching as any;
         expect(batching.has.movement).toBeFalsy();
         batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
         expect(batching.has.movement).toBeTruthy();
       });
 
-      it<CursorsTestContext>('creates a outgoingMovementBuffer for a new cursor', (context) => {
+      it<CursorsTestContext>('creates an outgoingBuffer for a new cursor movement', (context) => {
         const batching = context.batching as any;
         batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
         expect(batching.outgoingBuffers.movement.cursor1).toEqual([{ x: 1, y: 1 }]);
@@ -114,12 +114,60 @@ describe('Cursors (mockClient)', () => {
         ]);
       });
 
-      it<CursorsTestContext>('should start batchCursors correctly', (context) => {
+      it<CursorsTestContext>('should start batchToChannel correctly', (context) => {
         const batching = context.batching as any;
         batching.isRunning = false;
         batching.batchToChannel = vitest.fn();
         batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
         batching.pushCursorPosition('cursor1', { x: 1, y: 1 });
+        expect(batching.batchToChannel).toHaveBeenCalledOnce();
+        expect(batching.isRunning).toBeTruthy();
+      });
+    });
+
+    describe('pushCursorData', () => {
+      beforeEach<CursorsTestContext>((context) => {
+        const batching = context.batching as any;
+        // Set isRunning to true to avoid starting the loop here
+        batching.isRunning = true;
+        batching.shouldSend = true;
+      });
+
+      it<CursorsTestContext>('should ignore cursor updates if shouldSend is false', (context) => {
+        const batching = context.batching as any;
+        batching.shouldSend = false;
+        expect(batching.has.data).toBeFalsy();
+        batching.pushCursorData('cursor1', { color: 'red' });
+        expect(batching.has.data).toBeFalsy();
+      });
+
+      it<CursorsTestContext>('sets has.movements to true', (context) => {
+        const batching = context.batching as any;
+        expect(batching.has.data).toBeFalsy();
+        batching.pushCursorData('cursor1', { color: 'red' });
+        expect(batching.has.data).toBeTruthy();
+      });
+
+      it<CursorsTestContext>('creates an outgoingBuffer for a new cursor movement', (context) => {
+        const batching = context.batching as any;
+        batching.pushCursorData('cursor1', { color: 'red' });
+        expect(batching.outgoingBuffers.data.cursor1).toEqual([{ color: 'red' }]);
+      });
+
+      it<CursorsTestContext>('adds cursor data to an existing buffer', (context) => {
+        const batching = context.batching as any;
+        batching.pushCursorData('cursor1', { color: 'red' });
+        expect(batching.outgoingBuffers.data.cursor1).toEqual([{ color: 'red' }]);
+        batching.pushCursorData('cursor1', { color: 'green' });
+        expect(batching.outgoingBuffers.data.cursor1).toEqual([{ color: 'red' }, { color: 'green' }]);
+      });
+
+      it<CursorsTestContext>('should start batchToChannel correctly', (context) => {
+        const batching = context.batching as any;
+        batching.isRunning = false;
+        batching.batchToChannel = vitest.fn();
+        batching.pushCursorData('cursor1', { color: 'red' });
+        batching.pushCursorData('cursor1', { color: 'green' });
         expect(batching.batchToChannel).toHaveBeenCalledOnce();
         expect(batching.isRunning).toBeTruthy();
       });
@@ -163,7 +211,7 @@ describe('Cursors (mockClient)', () => {
         expect(batching.outgoingBuffers.movement).toEqual({});
       });
 
-      it<CursorsTestContext>('should set hasMovements to false', async (context) => {
+      it<CursorsTestContext>('should set has.movements to false', async (context) => {
         const batching = context.batching as any;
         batching.has.movement = true;
         await batching.batchToChannel('movement', CURSOR_POSITION_CHANNEL);

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -3,7 +3,7 @@ import { Realtime, Types } from 'ably/promises';
 import Space from './Space.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 import Cursor from './Cursor';
-import CursorBatching, { CURSOR_POSITION_CHANNEL } from './CursorBatching';
+import CursorBatching, { CURSOR_POSITION_EVENT } from './CursorBatching';
 
 interface CursorsTestContext {
   client: Types.RealtimePromise;
@@ -188,7 +188,7 @@ describe('Cursors (mockClient)', () => {
         batching.has.movement = false;
         batching.isRunning = true;
         const spy = vi.spyOn(space.cursors['channel'], 'publish');
-        await batching.batchToChannel('movement', CURSOR_POSITION_CHANNEL);
+        await batching.batchToChannel('movement', CURSOR_POSITION_EVENT);
         expect(batching.isRunning).toBeFalsy();
         expect(spy).not.toHaveBeenCalled();
       });
@@ -199,22 +199,22 @@ describe('Cursors (mockClient)', () => {
         batching.has.movement = true;
         batching.outgoingBuffers.movement = { cursor1: [{ x: 1, y: 1 }] };
         const spy = vi.spyOn(space.cursors['channel'], 'publish');
-        await batching.batchToChannel('movement', CURSOR_POSITION_CHANNEL);
-        expect(spy).toHaveBeenCalledWith(CURSOR_POSITION_CHANNEL, { cursor1: [{ x: 1, y: 1 }] });
+        await batching.batchToChannel('movement', CURSOR_POSITION_EVENT);
+        expect(spy).toHaveBeenCalledWith(CURSOR_POSITION_EVENT, { cursor1: [{ x: 1, y: 1 }] });
       });
 
       it<CursorsTestContext>('should clear the buffer', async (context) => {
         const batching = context.batching as any;
         batching.has.movement = true;
         batching.outgoingBuffers.movement = { cursor1: [{ x: 1, y: 1 }] };
-        await batching.batchToChannel('movement', CURSOR_POSITION_CHANNEL);
+        await batching.batchToChannel('movement', CURSOR_POSITION_EVENT);
         expect(batching.outgoingBuffers.movement).toEqual({});
       });
 
       it<CursorsTestContext>('should set has.movements to false', async (context) => {
         const batching = context.batching as any;
         batching.has.movement = true;
-        await batching.batchToChannel('movement', CURSOR_POSITION_CHANNEL);
+        await batching.batchToChannel('movement', CURSOR_POSITION_EVENT);
         expect(batching.has.movement).toBeFalsy();
       });
     });

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -11,7 +11,7 @@ type CursorData = Record<string, unknown>;
 
 type CursorUpdate = {
   position: CursorPosition;
-  data: CursorData;
+  data?: CursorData;
 };
 
 type CursorsEventMap = {

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -1,7 +1,7 @@
 import Space from './Space';
 import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
-import { CURSOR_EVENT, SPACE_CHANNEL_PREFIX } from './utilities/Constants';
+import { CURSOR_UPDATE, SPACE_CHANNEL_PREFIX } from './utilities/Constants';
 import { Types } from 'ably';
 import EventEmitter from './utilities/EventEmitter';
 
@@ -27,7 +27,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
   constructor(private space: Space) {
     super();
     this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
-    this.channel.subscribe(CURSOR_EVENT, this.onIncomingCursorUpdate.bind(this));
+    this.channel.subscribe(CURSOR_UPDATE, this.onIncomingCursorUpdate.bind(this));
     this.cursorBatching = new CursorBatching(this, this.channel);
   }
 

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -1,7 +1,7 @@
 import Space from './Space';
 import Cursor from './Cursor';
-import CursorBatching, { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT } from './CursorBatching';
-import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
+import CursorBatching from './CursorBatching';
+import { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT, SPACE_CHANNEL_PREFIX } from './utilities/Constants';
 import { Types } from 'ably';
 import EventEmitter from './utilities/EventEmitter';
 

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -1,6 +1,6 @@
 import Space from './Space';
 import Cursor from './Cursor';
-import CursorBatching, { CURSOR_DATA_CHANNEL, CURSOR_POSITION_CHANNEL } from './CursorBatching';
+import CursorBatching, { CURSOR_DATA_EVENT, CURSOR_POSITION_EVENT } from './CursorBatching';
 import { SPACE_CHANNEL_PREFIX } from './utilities/Constants';
 import { Types } from 'ably';
 import EventEmitter from './utilities/EventEmitter';
@@ -23,8 +23,8 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
   constructor(private space: Space) {
     super();
     this.channel = space.client.channels.get(`${SPACE_CHANNEL_PREFIX}_${space.name}_cursors`);
-    this.channel.subscribe(CURSOR_POSITION_CHANNEL, this.onIncomingCursorMovement.bind(this));
-    this.channel.subscribe(CURSOR_DATA_CHANNEL, this.onIncomingCursorData.bind(this));
+    this.channel.subscribe(CURSOR_POSITION_EVENT, this.onIncomingCursorMovement.bind(this));
+    this.channel.subscribe(CURSOR_DATA_EVENT, this.onIncomingCursorData.bind(this));
     this.cursorBatching = new CursorBatching(this, this.channel);
   }
 

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -1,1 +1,6 @@
-export const SPACE_CHANNEL_PREFIX = '_ably_space_';
+const SPACE_CHANNEL_PREFIX = '_ably_space_';
+
+const CURSOR_POSITION_EVENT = 'cursorPosition';
+const CURSOR_DATA_EVENT = 'cursorDataUpdate';
+
+export { SPACE_CHANNEL_PREFIX, CURSOR_POSITION_EVENT, CURSOR_DATA_EVENT };

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -1,6 +1,5 @@
 const SPACE_CHANNEL_PREFIX = '_ably_space_';
 
-const CURSOR_POSITION_EVENT = 'cursorPosition';
-const CURSOR_DATA_EVENT = 'cursorDataUpdate';
+const CURSOR_EVENT = '_event_cursor';
 
-export { SPACE_CHANNEL_PREFIX, CURSOR_POSITION_EVENT, CURSOR_DATA_EVENT };
+export { SPACE_CHANNEL_PREFIX, CURSOR_EVENT };

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -1,5 +1,5 @@
 const SPACE_CHANNEL_PREFIX = '_ably_space_';
 
-const CURSOR_EVENT = '_event_cursor';
+const CURSOR_UPDATE = 'cursor_update';
 
-export { SPACE_CHANNEL_PREFIX, CURSOR_EVENT };
+export { SPACE_CHANNEL_PREFIX, CURSOR_UPDATE };


### PR DESCRIPTION
The ticket is here:

[MMB-64](https://ably.atlassian.net/browse/MMB-64)

**Note:**
This changes the behaviour of the API considerably to work more in line with the [**Alternative Option** on DR7](https://ably.atlassian.net/wiki/spaces/product/pages/2529853584/DR7+Live+Cursor+API#Alternatives-considered.1).

The discussion precipitating this change can be found [here](https://docs.google.com/document/d/1a5VNpyDoHRo4hNvkmDO9Y3xeXMrZ8addBE3ObaCZEIs/edit#).

Most importantly, positionUpdates and dataUpdates are replaced by a single cursorUpdate event, and (differing from the DR) cursor data and position must both be consistently provided to the API.

This is to support:
* `getAll` functionality to retrieve most recent cursors from channel history
* reliable consistency of data, ensuring position and data are retained and are updated at the correct time