### PR TITLE
[MMB-111] Keep Space members by connection ID, not client ID

### DIFF
--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -37,4 +37,4 @@ class MockRealtime {
   }
 }
 
-export { MockRealtime as Realtime, mockPromisify };
+export { MockRealtime as Realtime };

--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -37,4 +37,4 @@ class MockRealtime {
   }
 }
 
-export { MockRealtime as Realtime };
+export { MockRealtime as Realtime, mockPromisify };

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -6,6 +6,7 @@ import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
 import { CURSOR_UPDATE } from './utilities/Constants.js';
 import CursorDispensing, { INCOMING_BUFFER_INTERVAL } from './CursorDispensing';
+import { mockPromisify } from '../__mocks__/ably/promises/index.js';
 
 interface CursorsTestContext {
   client: Types.RealtimePromise;
@@ -19,6 +20,39 @@ vi.mock('ably/promises');
 describe('Cursors (mockClient)', () => {
   beforeEach<CursorsTestContext>((context) => {
     const client = new Realtime({});
+    client.connection = {
+      id: '1',
+      ping: () => mockPromisify<number>(100),
+      whenState: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      errorReason: {
+        code: 20000,
+        message: '',
+        statusCode: 200,
+      },
+      recoveryKey: ``,
+      serial: 1,
+      state: `connected`,
+      close: () => mockPromisify(undefined),
+      on: () => mockPromisify(undefined),
+      off: () => mockPromisify(undefined),
+      connect: () => mockPromisify(undefined),
+      once: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      listeners: () => [],
+    };
     context.client = client;
     context.space = new Space('test', client);
     context.batching = context.space.cursors['cursorBatching'];

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -1,12 +1,11 @@
 import { it, describe, expect, vi, expectTypeOf, beforeEach, vitest, afterEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 import Space from './Space.js';
-import { createPresenceMessage } from './utilities/test/fakes.js';
+import { clientConnection, createPresenceMessage } from './utilities/test/fakes.js';
 import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
 import { CURSOR_UPDATE } from './utilities/Constants.js';
 import CursorDispensing, { INCOMING_BUFFER_INTERVAL } from './CursorDispensing';
-import { mockPromisify } from '../__mocks__/ably/promises/index.js';
 
 interface CursorsTestContext {
   client: Types.RealtimePromise;
@@ -20,39 +19,7 @@ vi.mock('ably/promises');
 describe('Cursors (mockClient)', () => {
   beforeEach<CursorsTestContext>((context) => {
     const client = new Realtime({});
-    client.connection = {
-      id: '1',
-      ping: () => mockPromisify<number>(100),
-      whenState: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      errorReason: {
-        code: 20000,
-        message: '',
-        statusCode: 200,
-      },
-      recoveryKey: ``,
-      serial: 1,
-      state: `connected`,
-      close: () => mockPromisify(undefined),
-      on: () => mockPromisify(undefined),
-      off: () => mockPromisify(undefined),
-      connect: () => mockPromisify(undefined),
-      once: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      listeners: () => [],
-    };
+    client.connection = clientConnection;
     context.client = client;
     context.space = new Space('test', client);
     context.batching = context.space.cursors['cursorBatching'];

--- a/src/LocationTracker.mockClient.test.ts
+++ b/src/LocationTracker.mockClient.test.ts
@@ -4,6 +4,7 @@ import Locations, { LocationChange } from './Locations';
 import LocationTracker, { LocationTrackerPredicate } from './LocationTracker';
 import { Realtime } from 'ably/promises';
 import { createPresenceMessage } from './utilities/test/fakes';
+import { mockPromisify } from '../__mocks__/ably/promises';
 
 const MOCK_CLIENT_ID = 'MOCK_CLIENT_ID';
 
@@ -20,6 +21,39 @@ vi.mock('ably/promises');
 describe('LocationTracker', () => {
   beforeEach<LocationsTrackerTestContext>((context) => {
     const client = new Realtime({});
+    client.connection = {
+      id: '1',
+      ping: () => mockPromisify<number>(100),
+      whenState: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      errorReason: {
+        code: 20000,
+        message: '',
+        statusCode: 200,
+      },
+      recoveryKey: ``,
+      serial: 1,
+      state: `connected`,
+      close: () => mockPromisify(undefined),
+      on: () => mockPromisify(undefined),
+      off: () => mockPromisify(undefined),
+      connect: () => mockPromisify(undefined),
+      once: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      listeners: () => [],
+    };
 
     const presence = client.channels.get('').presence;
 
@@ -46,7 +80,7 @@ describe('LocationTracker', () => {
 
     const spaceMember = {
       clientId: '1',
-      connections: ['1'],
+      connectionId: '1',
       isConnected: true,
       profileData: {},
       location: null,
@@ -149,7 +183,7 @@ describe('LocationTracker', () => {
     expect(locationTracker.members()).toEqual([
       {
         clientId: 'MOCK_CLIENT_ID',
-        connections: ['1'],
+        connectionId: '1',
         isConnected: true,
         lastEvent: {
           name: 'enter',

--- a/src/LocationTracker.mockClient.test.ts
+++ b/src/LocationTracker.mockClient.test.ts
@@ -3,8 +3,7 @@ import Space, { SpaceMember } from './Space';
 import Locations, { LocationChange } from './Locations';
 import LocationTracker, { LocationTrackerPredicate } from './LocationTracker';
 import { Realtime } from 'ably/promises';
-import { createPresenceMessage } from './utilities/test/fakes';
-import { mockPromisify } from '../__mocks__/ably/promises';
+import { clientConnection, createPresenceMessage } from './utilities/test/fakes';
 
 const MOCK_CLIENT_ID = 'MOCK_CLIENT_ID';
 
@@ -21,39 +20,7 @@ vi.mock('ably/promises');
 describe('LocationTracker', () => {
   beforeEach<LocationsTrackerTestContext>((context) => {
     const client = new Realtime({});
-    client.connection = {
-      id: '1',
-      ping: () => mockPromisify<number>(100),
-      whenState: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      errorReason: {
-        code: 20000,
-        message: '',
-        statusCode: 200,
-      },
-      recoveryKey: ``,
-      serial: 1,
-      state: `connected`,
-      close: () => mockPromisify(undefined),
-      on: () => mockPromisify(undefined),
-      off: () => mockPromisify(undefined),
-      connect: () => mockPromisify(undefined),
-      once: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      listeners: () => [],
-    };
+    client.connection = clientConnection;
 
     const presence = client.channels.get('').presence;
 

--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -2,6 +2,7 @@ import { it, describe, expect, vi, beforeEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 import Space, { SpaceMember } from './Space.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
+import { mockPromisify } from '../__mocks__/ably/promises/index.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
@@ -14,6 +15,39 @@ vi.mock('ably/promises');
 describe('Locations (mockClient)', () => {
   beforeEach<SpaceTestContext>((context) => {
     const client = new Realtime({});
+    client.connection = {
+      id: '1',
+      ping: () => mockPromisify<number>(100),
+      whenState: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      errorReason: {
+        code: 20000,
+        message: '',
+        statusCode: 200,
+      },
+      recoveryKey: ``,
+      serial: 1,
+      state: `connected`,
+      close: () => mockPromisify(undefined),
+      on: () => mockPromisify(undefined),
+      off: () => mockPromisify(undefined),
+      connect: () => mockPromisify(undefined),
+      once: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      listeners: () => [],
+    };
     const presence = client.channels.get('').presence;
 
     vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
@@ -61,11 +95,11 @@ describe('Locations (mockClient)', () => {
       expect(spy).toHaveBeenLastCalledWith<{ member: SpaceMember; currentLocation: any; previousLocation: any }[]>({
         member: {
           clientId: '2',
+          connectionId: '2',
           isConnected: true,
           profileData: { a: 1 },
           location: 'location2',
           lastEvent: { name: 'update', timestamp: 1 },
-          connections: ['2'],
         },
         currentLocation: 'location2',
         previousLocation: 'location1',

--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -1,8 +1,7 @@
 import { it, describe, expect, vi, beforeEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 import Space, { SpaceMember } from './Space.js';
-import { createPresenceMessage } from './utilities/test/fakes.js';
-import { mockPromisify } from '../__mocks__/ably/promises/index.js';
+import { clientConnection, createPresenceMessage } from './utilities/test/fakes.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
@@ -15,39 +14,7 @@ vi.mock('ably/promises');
 describe('Locations (mockClient)', () => {
   beforeEach<SpaceTestContext>((context) => {
     const client = new Realtime({});
-    client.connection = {
-      id: '1',
-      ping: () => mockPromisify<number>(100),
-      whenState: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      errorReason: {
-        code: 20000,
-        message: '',
-        statusCode: 200,
-      },
-      recoveryKey: ``,
-      serial: 1,
-      state: `connected`,
-      close: () => mockPromisify(undefined),
-      on: () => mockPromisify(undefined),
-      off: () => mockPromisify(undefined),
-      connect: () => mockPromisify(undefined),
-      once: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      listeners: () => [],
-    };
+    client.connection = clientConnection;
     const presence = client.channels.get('').presence;
 
     vi.spyOn(presence, 'get').mockImplementationOnce(async () => [

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -2,10 +2,9 @@ import { it, describe, expect, vi, beforeEach, expectTypeOf, afterEach } from 'v
 import { Realtime, Types } from 'ably/promises';
 
 import Space, { SpaceMember } from './Space.js';
-import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes.js';
+import { clientConnection, createPresenceEvent, createPresenceMessage } from './utilities/test/fakes.js';
 import Locations from './Locations.js';
 import Cursors from './Cursors';
-import { mockPromisify } from '../__mocks__/ably/promises/index.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
@@ -18,39 +17,7 @@ vi.mock('ably/promises');
 describe('Space (mockClient)', () => {
   beforeEach<SpaceTestContext>((context) => {
     const client = new Realtime({});
-    client.connection = {
-      id: '1',
-      ping: () => mockPromisify<number>(100),
-      whenState: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      errorReason: {
-        code: 20000,
-        message: '',
-        statusCode: 200,
-      },
-      recoveryKey: ``,
-      serial: 1,
-      state: `connected`,
-      close: () => mockPromisify(undefined),
-      on: () => mockPromisify(undefined),
-      off: () => mockPromisify(undefined),
-      connect: () => mockPromisify(undefined),
-      once: () =>
-        mockPromisify<{
-          current: 'connected';
-          previous: 'disconnected';
-        }>({
-          current: 'connected',
-          previous: 'disconnected',
-        }),
-      listeners: () => [],
-    };
+    client.connection = clientConnection;
     const presence = client.channels.get('').presence;
 
     context.client = client;
@@ -135,39 +102,7 @@ describe('Space (mockClient)', () => {
   describe('on', () => {
     it('subscribes to presence updates', async () => {
       const client = new Realtime({});
-      client.connection = {
-        id: '1',
-        ping: () => mockPromisify<number>(100),
-        whenState: () =>
-          mockPromisify<{
-            current: 'connected';
-            previous: 'disconnected';
-          }>({
-            current: 'connected',
-            previous: 'disconnected',
-          }),
-        errorReason: {
-          code: 20000,
-          message: '',
-          statusCode: 200,
-        },
-        recoveryKey: ``,
-        serial: 1,
-        state: `connected`,
-        close: () => mockPromisify(undefined),
-        on: () => mockPromisify(undefined),
-        off: () => mockPromisify(undefined),
-        connect: () => mockPromisify(undefined),
-        once: () =>
-          mockPromisify<{
-            current: 'connected';
-            previous: 'disconnected';
-          }>({
-            current: 'connected',
-            previous: 'disconnected',
-          }),
-        listeners: () => [],
-      };
+      client.connection = clientConnection;
       const presence = client.channels.get('').presence;
       const spy = vi.spyOn(presence, 'subscribe');
       new Space('test', client);

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -5,6 +5,7 @@ import Space, { SpaceMember } from './Space.js';
 import { createPresenceEvent, createPresenceMessage } from './utilities/test/fakes.js';
 import Locations from './Locations.js';
 import Cursors from './Cursors';
+import { mockPromisify } from '../__mocks__/ably/promises/index.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
@@ -17,6 +18,39 @@ vi.mock('ably/promises');
 describe('Space (mockClient)', () => {
   beforeEach<SpaceTestContext>((context) => {
     const client = new Realtime({});
+    client.connection = {
+      id: '1',
+      ping: () => mockPromisify<number>(100),
+      whenState: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      errorReason: {
+        code: 20000,
+        message: '',
+        statusCode: 200,
+      },
+      recoveryKey: ``,
+      serial: 1,
+      state: `connected`,
+      close: () => mockPromisify(undefined),
+      on: () => mockPromisify(undefined),
+      off: () => mockPromisify(undefined),
+      connect: () => mockPromisify(undefined),
+      once: () =>
+        mockPromisify<{
+          current: 'connected';
+          previous: 'disconnected';
+        }>({
+          current: 'connected',
+          previous: 'disconnected',
+        }),
+      listeners: () => [],
+    };
     const presence = client.channels.get('').presence;
 
     context.client = client;
@@ -31,7 +65,6 @@ describe('Space (mockClient)', () => {
       const space = new Space('test', client);
 
       expect(channelSpy).toHaveBeenNthCalledWith(1, '_ably_space_test');
-      // Note: This is matching the class type. This is not a TypeScript type.
       expectTypeOf(space).toMatchTypeOf<Space>();
     });
   });
@@ -52,7 +85,7 @@ describe('Space (mockClient)', () => {
       expect(spaceMembers).toEqual<SpaceMember[]>([
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           isConnected: true,
           profileData: {},
           location: null,
@@ -60,7 +93,7 @@ describe('Space (mockClient)', () => {
         },
         {
           clientId: '2',
-          connections: ['2'],
+          connectionId: '2',
           isConnected: true,
           profileData: { a: 1 },
           location: null,
@@ -77,7 +110,7 @@ describe('Space (mockClient)', () => {
       const member = space.getMemberFromConnection('testConnectionId');
       expect(member).toEqual<SpaceMember>({
         clientId: '1',
-        connections: ['testConnectionId'],
+        connectionId: 'testConnectionId',
         isConnected: true,
         location: null,
         lastEvent: {
@@ -102,6 +135,39 @@ describe('Space (mockClient)', () => {
   describe('on', () => {
     it('subscribes to presence updates', async () => {
       const client = new Realtime({});
+      client.connection = {
+        id: '1',
+        ping: () => mockPromisify<number>(100),
+        whenState: () =>
+          mockPromisify<{
+            current: 'connected';
+            previous: 'disconnected';
+          }>({
+            current: 'connected',
+            previous: 'disconnected',
+          }),
+        errorReason: {
+          code: 20000,
+          message: '',
+          statusCode: 200,
+        },
+        recoveryKey: ``,
+        serial: 1,
+        state: `connected`,
+        close: () => mockPromisify(undefined),
+        on: () => mockPromisify(undefined),
+        off: () => mockPromisify(undefined),
+        connect: () => mockPromisify(undefined),
+        once: () =>
+          mockPromisify<{
+            current: 'connected';
+            previous: 'disconnected';
+          }>({
+            current: 'connected',
+            previous: 'disconnected',
+          }),
+        listeners: () => [],
+      };
       const presence = client.channels.get('').presence;
       const spy = vi.spyOn(presence, 'subscribe');
       new Space('test', client);
@@ -125,7 +191,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: true,
           location: null,
@@ -137,7 +203,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: true,
           location: null,
@@ -145,7 +211,7 @@ describe('Space (mockClient)', () => {
         },
         {
           clientId: '2',
-          connections: ['2'],
+          connectionId: '2',
           profileData: { a: 1 },
           isConnected: true,
           location: null,
@@ -162,7 +228,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: true,
           location: null,
@@ -174,7 +240,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: { a: 1 },
           isConnected: true,
           location: null,
@@ -191,7 +257,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: true,
           location: null,
@@ -203,7 +269,7 @@ describe('Space (mockClient)', () => {
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: false,
           location: null,
@@ -220,7 +286,7 @@ describe('Space (mockClient)', () => {
 
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[]>(1, {
         clientId: '1',
-        connections: ['1'],
+        connectionId: '1',
         profileData: {},
         isConnected: true,
         location: null,
@@ -245,7 +311,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: true,
             location: null,
@@ -257,7 +323,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: false,
             location: null,
@@ -282,7 +348,7 @@ describe('Space (mockClient)', () => {
 
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[]>(1, {
           clientId: '1',
-          connections: ['1'],
+          connectionId: '1',
           profileData: {},
           isConnected: false,
           location: null,
@@ -299,7 +365,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: true,
             location: null,
@@ -307,7 +373,7 @@ describe('Space (mockClient)', () => {
           },
           {
             clientId: '2',
-            connections: ['2'],
+            connectionId: '2',
             profileData: {},
             isConnected: true,
             location: null,
@@ -319,7 +385,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: false,
             location: null,
@@ -327,7 +393,7 @@ describe('Space (mockClient)', () => {
           },
           {
             clientId: '2',
-            connections: ['2'],
+            connectionId: '2',
             profileData: {},
             isConnected: true,
             location: null,
@@ -340,7 +406,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: true,
             location: null,
@@ -348,7 +414,7 @@ describe('Space (mockClient)', () => {
           },
           {
             clientId: '2',
-            connections: ['2'],
+            connectionId: '2',
             profileData: {},
             isConnected: true,
             location: null,
@@ -360,7 +426,7 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
           {
             clientId: '1',
-            connections: ['1'],
+            connectionId: '1',
             profileData: {},
             isConnected: true,
             location: null,
@@ -368,7 +434,7 @@ describe('Space (mockClient)', () => {
           },
           {
             clientId: '2',
-            connections: ['2'],
+            connectionId: '2',
             profileData: {},
             isConnected: true,
             location: null,

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -68,7 +68,7 @@ class Space extends EventEmitter<SpaceEventsMap> {
     this.channel.presence.subscribe(this.onPresenceUpdate);
   }
 
-  getMemberFromConnection(connectionId: string) {
+  getMemberFromConnection(connectionId?: string) {
     return this.members.find((m) => m.connectionId === connectionId);
   }
 

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -1,3 +1,5 @@
+import { mockPromisify } from '../../../__mocks__/ably/promises';
+
 const enterPresenceMessage = {
   clientId: '1',
   data: { profileData: {} },
@@ -36,4 +38,38 @@ const createPresenceEvent = (space, type, override?) => {
   space.onPresenceUpdate(createPresenceMessage(type, override));
 };
 
-export { createPresenceMessage, createPresenceEvent };
+const clientConnection = {
+  id: '1',
+  ping: () => mockPromisify<number>(100),
+  whenState: () =>
+    mockPromisify<{
+      current: 'connected';
+      previous: 'disconnected';
+    }>({
+      current: 'connected',
+      previous: 'disconnected',
+    }),
+  errorReason: {
+    code: 20000,
+    message: '',
+    statusCode: 200,
+  },
+  recoveryKey: ``,
+  serial: 1,
+  state: `connected`,
+  close: () => mockPromisify(undefined),
+  on: () => mockPromisify(undefined),
+  off: () => mockPromisify(undefined),
+  connect: () => mockPromisify(undefined),
+  once: () =>
+    mockPromisify<{
+      current: 'connected';
+      previous: 'disconnected';
+    }>({
+      current: 'connected',
+      previous: 'disconnected',
+    }),
+  listeners: () => [],
+} as const;
+
+export { createPresenceMessage, createPresenceEvent, clientConnection };

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -1,4 +1,4 @@
-import { mockPromisify } from '../../../__mocks__/ably/promises';
+const mockPromisify = <T>(expectedReturnValue: T): Promise<T> => new Promise((resolve) => resolve(expectedReturnValue));
 
 const enterPresenceMessage = {
   clientId: '1',


### PR DESCRIPTION
Keep Space Members by connection ID, not client ID.

Connection ID does not always exist, however it will always exist as long as Spaces is relevant; therefore, I think this implementation should be feasible.

Check that things still work on this review app:

https://645cb3c6550a247a98488cae--spaces-demo.netlify.app/?space=idea-garden-breathe