### PR TITLE
[MMB-125] All cursor events are repeated fix

### DIFF
--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -27,11 +27,19 @@ const mockHistory = {
   isLast: () => true,
 };
 
+const mockEmitter = {
+  any: [],
+  events: {},
+  anyOnce: [],
+  eventsOnce: {},
+};
+
 const mockChannel = {
   presence: mockPresence,
   history: () => mockHistory,
   subscribe: () => {},
   publish: () => {},
+  subscriptions: mockEmitter,
 };
 
 class MockRealtime {

--- a/demo/app/components/cursors.ts
+++ b/demo/app/components/cursors.ts
@@ -87,17 +87,24 @@ const attachCursors = (space, slideId) => {
       const { top, left } = cursorContainer.getBoundingClientRect();
       cursor.set({ position: { x: event.clientX - left, y: event.clientY - top }, data: { state: 'leave' } });
     },
+    tabLeft: (event) => {
+      if (document.visibilityState === 'hidden') {
+        cursorHandlers.leave(event);
+      }
+    },
   };
 
   slideContainer.addEventListener('mouseenter', cursorHandlers.enter);
   slideContainer.addEventListener('mousemove', cursorHandlers.move);
   slideContainer.addEventListener('mouseleave', cursorHandlers.leave);
+  document.addEventListener('visibilitychange', cursorHandlers.tabLeft);
 
   return () => {
     cursor.off();
     slideContainer.removeEventListener('mouseenter', cursorHandlers.enter);
     slideContainer.removeEventListener('mousemove', cursorHandlers.move);
     slideContainer.removeEventListener('mouseleave', cursorHandlers.leave);
+    document.addEventListener('visibilitychange', cursorHandlers.tabLeft);
   };
 };
 

--- a/demo/app/components/cursors.ts
+++ b/demo/app/components/cursors.ts
@@ -48,6 +48,7 @@ const createCursor = (connectionId: string, profileData: { name: string; color: 
 const attachCursors = (space, slideId) => {
   const slideContainer = document.querySelector('#slide-selected') as HTMLElement;
   const cursorContainer = queryDataId(slideContainer, 'slide-cursor-container');
+  cursorContainer.innerHTML = '';
 
   const cursor = space.cursors.get(slideId);
   const self = space.getSelf();
@@ -94,7 +95,6 @@ const attachCursors = (space, slideId) => {
 
   return () => {
     cursor.off();
-    cursorContainer.innerHTML = '';
     slideContainer.removeEventListener('mouseenter', cursorHandlers.enter);
     slideContainer.removeEventListener('mousemove', cursorHandlers.move);
     slideContainer.removeEventListener('mouseleave', cursorHandlers.leave);

--- a/demo/app/components/cursors.ts
+++ b/demo/app/components/cursors.ts
@@ -54,14 +54,6 @@ const attachCursors = (space, slideId) => {
 
   cursor.on('cursorUpdate', (update) => {
     let cursorNode: HTMLElement = slideContainer.querySelector(`#cursor-${update.connectionId}`);
-    const now = Date.now();
-    const batchTime = space.cursors['cursorBatching']['batchTime'] * 3;
-    const oldBatch = now - update.batchTimestamp > batchTime;
-
-    if (oldBatch) {
-      cursorNode ? cursorContainer.removeChild(cursorNode) : null;
-      return;
-    }
 
     const membersOnSlide = space.getMembers().filter((member) => member.location?.slide === slideId);
     const member = membersOnSlide.find((member) => member.connectionId === update.connectionId);

--- a/demo/app/components/simulate.ts
+++ b/demo/app/components/simulate.ts
@@ -76,11 +76,11 @@ class Simulate {
 
   cursors(
     interval: number = Math.floor(Math.random() * 50),
-    executeFor: number = 5_000,
-    initialX: number = 10,
-    initialY: number = 10,
-    incrementX: number = 5,
-    incrementY: number = 5,
+    executeFor: number = 30_000,
+    initialX: number = Math.floor(Math.random() * 20),
+    initialY: number = Math.floor(Math.random() * 20),
+    incrementX: number = Math.floor(Math.random() * 5),
+    incrementY: number = Math.floor(Math.random() * 5),
   ) {
     return new CursorMovements(interval, executeFor, initialX, initialY, incrementX, incrementY);
   }

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -28,9 +28,9 @@ const selfName = getRandomName();
 const selfColor = getRandomColor();
 const memberIsNotSelf = (member: SpaceMember) => member.clientId !== clientId;
 const currentSlide = () => slideData.find((slide) => slide.selected === IS_SELECTED);
-const sameSlideDifferentElement = (previousLocation, currentLocation) =>
-  previousLocation?.slide === currentLocation?.slide && previousLocation?.element !== currentLocation?.element;
-
+const sameSlide = (previousLocation, currentLocation) => {
+  return previousLocation?.slide === currentLocation?.slide;
+};
 const ably = new Ably.Realtime.Promise({
   authUrl: `/api/ably-token-request?clientId=${clientId}`,
   clientId,
@@ -39,7 +39,7 @@ const ably = new Ably.Realtime.Promise({
 const spaces = new Spaces(ably);
 const space = await spaces.get(getSpaceNameFromUrl(), {
   offlineTimeout: 10_000,
-  cursors: { outboundBatchInterval: 100, inboundBatchInterval: 1 },
+  cursors: { outboundBatchInterval: 50, inboundBatchInterval: 1 },
 });
 
 space.on(MEMBERS_UPDATE, (members) => {
@@ -60,7 +60,7 @@ space.locations.on('locationUpdate', ({ previousLocation, currentLocation }) => 
   renderSlidePreviewMenu(space);
   renderSelectedSlide(space);
 
-  if (sameSlideDifferentElement(previousLocation, currentLocation)) return;
+  if (sameSlide(previousLocation, currentLocation)) return;
   detachCursors();
   detachCursors = attachCursors(space, currentSlide().id);
 });

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -39,7 +39,6 @@ const ably = new Ably.Realtime.Promise({
 const spaces = new Spaces(ably);
 const space = await spaces.get(getSpaceNameFromUrl(), {
   offlineTimeout: 10_000,
-  cursors: { outboundBatchInterval: 50, inboundBatchInterval: 1 },
 });
 
 space.on(MEMBERS_UPDATE, (members) => {

--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -1,4 +1,4 @@
-import Cursors, { CursorUpdate } from './Cursors';
+import { CursorUpdate } from './Cursors';
 import { Types } from 'ably';
 import { CURSOR_UPDATE } from './utilities/Constants';
 import type { StrictCursorsOptions } from './options/CursorsOptions';
@@ -18,7 +18,6 @@ export default class CursorBatching {
   // Set to `true` if there is more than one user listening to cursors
 
   constructor(
-    readonly cursors: Cursors,
     readonly channel: Types.RealtimeChannelPromise,
     readonly outboundBatchInterval: StrictCursorsOptions['outboundBatchInterval'],
   ) {

--- a/src/CursorDispensing.ts
+++ b/src/CursorDispensing.ts
@@ -68,7 +68,6 @@ export default class CursorDispensing {
           name,
           clientId: message.clientId,
           connectionId: message.connectionId,
-          updateTimestamp: message.timestamp,
           position: update.position,
           data: update.data,
         };

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -78,7 +78,6 @@ describe('Cursors (mockClient)', () => {
         position: { x: 1, y: 1 },
         data: undefined,
         clientId: 'clientId',
-        batchTimestamp: 1,
         connectionId: 'connectionId',
         name: 'cursor1',
       });
@@ -88,7 +87,6 @@ describe('Cursors (mockClient)', () => {
       expect(spy).toHaveBeenCalledWith({
         position: { x: 1, y: 2 },
         data: { color: 'red' },
-        batchTimestamp: 1,
         clientId: 'clientId',
         connectionId: 'connectionId',
         name: 'cursor2',
@@ -119,7 +117,6 @@ describe('Cursors (mockClient)', () => {
       const result = {
         position: { x: 1, y: 1 },
         data: undefined,
-        batchTimestamp: 1,
         clientId: 'clientId',
         connectionId: 'connectionId',
         name: 'cursor1',
@@ -323,7 +320,6 @@ describe('Cursors (mockClient)', () => {
               data: undefined,
               clientId: 'clientId',
               connectionId: 'connectionId',
-              batchTimestamp: 1,
               name: 'cursor1',
             },
             {
@@ -331,7 +327,6 @@ describe('Cursors (mockClient)', () => {
               data: { color: 'blue' },
               clientId: 'clientId',
               connectionId: 'connectionId',
-              batchTimestamp: 1,
               name: 'cursor1',
             },
             {
@@ -339,7 +334,6 @@ describe('Cursors (mockClient)', () => {
               data: undefined,
               clientId: 'clientId',
               connectionId: 'connectionId',
-              batchTimestamp: 1,
               name: 'cursor2',
             },
           ],

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -5,7 +5,6 @@ import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
 import CursorDispensing from './CursorDispensing';
 import {
-  CURSOR_UPDATE,
   OUTGOING_BATCH_TIME_DEFAULT,
   INCOMING_BATCH_TIME_DEFAULT,
   PAGINATION_LIMIT_DEFAULT,
@@ -52,17 +51,14 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     }
     const spaceChannelName = space.getChannelName();
     this.channel = space.client.channels.get(`${spaceChannelName}_cursors`);
-    this.cursorBatching = new CursorBatching(this, this.channel, this.options.outboundBatchInterval);
-
-    this.cursorDispensing = new CursorDispensing(this, this.options.inboundBatchInterval);
-    this.channel.subscribe(CURSOR_UPDATE, (message) => this.cursorDispensing.processBatch(message));
-
+    this.cursorBatching = new CursorBatching(this.channel, this.options.outboundBatchInterval);
     this.cursorHistory = new CursorHistory(this.channel, this.options.paginationLimit);
+    this.cursorDispensing = new CursorDispensing(this, this.options.inboundBatchInterval);
   }
 
   get(name: string): Cursor {
     if (!this.cursors[name]) {
-      this.cursors[name] = new Cursor(name, this.cursorBatching);
+      this.cursors[name] = new Cursor(name, this.channel, this.cursorBatching, this.cursorDispensing);
     }
 
     return this.cursors[name];


### PR DESCRIPTION
When a user leaves a tab, all methods that use timers are delayed by the browser, most often to at least a second (or more). Because we dispense cursor positions at 1ms, this has the potential to create a massive backlog of events when a user comes back to that tab. To handle this, we check the `visibilityState` of a tab when processing events. If the tab is hidden, we process them immediately, without the setTimeout (which should be rapid as it would not trigger any repaints).

We also refactor how cursors use channels. Each cursor creates their own subscription, so when we detach we can remove channel subscription together with cursor emitter subscriptions.