### PR TITLE
Measured position dispensing

### DIFF
--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -52,12 +52,6 @@ The interval at which a batch of cursors position is published. This is multipli
 
 Default 100ms.
 
-##### inboundBatchInterval
-
-The interval at which the listener for cursor positions is updated with a single position.
-
-Default is 1ms.
-
 ##### paginationLimit
 
 The number of [history API](https://ably.com/docs/realtime/history) pages searched for the last published cursor position.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,17 +1,17 @@
 # In-depth usage
 
-* [Authenticate and instantiate](#authenticate-and-instantiate)
-* [Create a space](#create-a-space)
-* [Subscribe to member updates](#subscribe-to-member-updates)
-  * [Request member updates](#request-member-updates)
-* [Enter a space](#enter-a-space)
-  * [Leave a space](#leave-a-space)
-* [Subscribe to location updates](#subscribe-to-location-updates)
-  * [Track an individual location or user](#track-an-individual-location-or-user)
-* [Set a location](#set-a-location)
-* [Subscribe to cursor updates](#subscribe-to-cursor-updates)
-  * [Request cursor locations](#request-cursor-locations)
-* [Set a cursor location](#set-a-cursor-location)
+- [Authenticate and instantiate](#authenticate-and-instantiate)
+- [Create a space](#create-a-space)
+- [Subscribe to member updates](#subscribe-to-member-updates)
+  - [Request member updates](#request-member-updates)
+- [Enter a space](#enter-a-space)
+  - [Leave a space](#leave-a-space)
+- [Subscribe to location updates](#subscribe-to-location-updates)
+  - [Track an individual location or user](#track-an-individual-location-or-user)
+- [Set a location](#set-a-location)
+- [Subscribe to cursor updates](#subscribe-to-cursor-updates)
+  - [Request cursor locations](#request-cursor-locations)
+- [Set a cursor location](#set-a-cursor-location)
 
 ## Authenticate and instantiate
 
@@ -43,13 +43,11 @@ const space = spaces.get('demoSlideshow');
 
 A set of `spaceOptions` can be passed to space when creating or retrieving it. `spaceOptions` enable additional properties to be set for the space. The following properties can be set:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| offlineTimeout | The time in milliseconds before a member is removed from a space after they have disconnected. The default is 120,000 (2 minutes). | number |
-| outboundBatchInterval | The interval in milliseconds at which a batch of cursor positions are published. This is multiplied  by the number of members in the space minus 1. The default value is 100. | number |
-| inboundBatchInterval | The interval in milliseconds at which a listener is updated with a single cursor position change. The default is 1. | number |
-| paginationLimit | The number of pages searched from [history](https://ably.com/docs/realtime/history) for the last published cursor position. The default is 5. | number |
-
+| Property              | Description                                                                                                                                                                  | Type   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| offlineTimeout        | The time in milliseconds before a member is removed from a space after they have disconnected. The default is 120,000 (2 minutes).                                           | number |
+| outboundBatchInterval | The interval in milliseconds at which a batch of cursor positions are published. This is multiplied by the number of members in the space minus 1. The default value is 100. | number |
+| paginationLimit       | The number of pages searched from [history](https://ably.com/docs/realtime/history) for the last published cursor position. The default is 5.                                | number |
 
 The following is an example of setting `offlineTimeout` to 3 minutes when creating a space:
 
@@ -91,19 +89,19 @@ The following is an example `membersUpdate` event received by subscribers when a
 
 The following are the properties of a `spaceMember` event:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| clientId | The client identifier for the user. | string |
-| isConnected | Whether the user is connected to Ably or not. | boolean |
-| lastEvent | The most recent event emitted by the user and its timestamp. Events will be either `enter` or `leave`. | {name: string, timestamp: number} |
-| location | The current location of the user within the space. | any |
-| profileData | Optional user data that can be attached to a user, such as a username or image to display in an avatar stack. | object |
+| Property    | Description                                                                                                   | Type                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| clientId    | The client identifier for the user.                                                                           | string                            |
+| isConnected | Whether the user is connected to Ably or not.                                                                 | boolean                           |
+| lastEvent   | The most recent event emitted by the user and its timestamp. Events will be either `enter` or `leave`.        | {name: string, timestamp: number} |
+| location    | The current location of the user within the space.                                                            | any                               |
+| profileData | Optional user data that can be attached to a user, such as a username or image to display in an avatar stack. | object                            |
 
 To stop subscribing to member events, users can call the `space.off()` method.
 
 ### Request member updates
 
-In addition to subscribing to events to see who joins and leaves a space, it is also possible to query the membership of a space in a one-off request using `getMembers()`. This returns an array of `spaceMember` objects. 
+In addition to subscribing to events to see who joins and leaves a space, it is also possible to query the membership of a space in a one-off request using `getMembers()`. This returns an array of `spaceMember` objects.
 
 The `getSelf()` method can be used to return the `spaceMember` object for the local client.
 
@@ -117,8 +115,8 @@ The following is an example of entering a space with `profileData`:
 
 ```ts
 space.enter({
-  username: "Claire Lemons",
-  avatar: "https://slides-internal.com/users/clemons.png",
+  username: 'Claire Lemons',
+  avatar: 'https://slides-internal.com/users/clemons.png',
 });
 ```
 
@@ -126,10 +124,10 @@ space.enter({
 
 A leave event is sent when a user leaves a space. This can occur for one of the following reasons:
 
-* `space.leave()` is called explicitly.
-* The user closes the tab.
-* The user is abruptly disconnected from the internet for longer than 2 minutes.
-  * Note that the time before they are seen has having left the space is configurable using [`offlineTimeout`](#create-a-space).
+- `space.leave()` is called explicitly.
+- The user closes the tab.
+- The user is abruptly disconnected from the internet for longer than 2 minutes.
+  - Note that the time before they are seen has having left the space is configurable using [`offlineTimeout`](#create-a-space).
 
 ## Subscribe to location updates
 
@@ -160,32 +158,32 @@ The following is an example `locationUpdate` event received by subscribers when 
       "avatar": "https://slides-internal.com/users/clemons.png"
     },
     "location": {
-      "slide": "3", 
+      "slide": "3",
       "component": "slide-title"
-      },
-    "lastEvent": { 
-      "name": "update", 
-      "timestamp": 1 
-      }
+    },
+    "lastEvent": {
+      "name": "update",
+      "timestamp": 1
+    }
   },
   "previousLocation": {
-    "slide": "2", 
-    "component": null 
-    },
+    "slide": "2",
+    "component": null
+  },
   "currentLocation": {
-    "slide": "3", 
+    "slide": "3",
     "component": "slide-title"
-    }
+  }
 }
 ```
 
 The following are the properties of a `locationUpdate` event:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| member | The details of the user that has changed location. | [`spaceMember`](#subscribe-to-member-updates) |
-| previousLocation | The previous location of the user within the space. | any |
-| currentLocation | The current location of the user within the space. | any |
+| Property         | Description                                         | Type                                          |
+| ---------------- | --------------------------------------------------- | --------------------------------------------- |
+| member           | The details of the user that has changed location.  | [`spaceMember`](#subscribe-to-member-updates) |
+| previousLocation | The previous location of the user within the space. | any                                           |
+| currentLocation  | The current location of the user within the space.  | any                                           |
 
 To stop subscribing to location updates, users can call the `locations.off()` method.
 
@@ -196,9 +194,7 @@ It is also possible to track a specific location or user, rather than subscribin
 The following is an example of creating a tracker for a specific user based on their `clientId`, and then subscribing to updates for only that user:
 
 ```ts
-const memberTracker = space.locations.createTracker(
-  (change) => change.member.clientId === 'clemons#142'
-);
+const memberTracker = space.locations.createTracker((change) => change.member.clientId === 'clemons#142');
 
 memberTracker.on((change) => {
   console.log(change);
@@ -208,9 +204,7 @@ memberTracker.on((change) => {
 The following is an example of creating a tracker for a specific location, such as a single UI element, and then subscribing to updates for only that location:
 
 ```ts
-const locationTracker = space.locations.createTracker(
-  (change) => change.previousLocation === 'slide-title'
-);
+const locationTracker = space.locations.createTracker((change) => change.previousLocation === 'slide-title');
 
 locationTracker.on((change) => {
   console.log(change);
@@ -221,10 +215,10 @@ locationTracker.on((change) => {
 
 Users call `locations.set()` to publish a `locationUpdate` that will be received by all users subscribed to location updates. This should be called to update their location when they change position, or select a new UI element.
 
-The following is an example of setting a location update: 
+The following is an example of setting a location update:
 
 ```ts
-space.locations.set({slide: '3', component: 'slide-title'});
+space.locations.set({ slide: '3', component: 'slide-title' });
 ```
 
 ## Subscribe to cursor updates
@@ -235,7 +229,7 @@ The following is an example of subscribing to all cursor updates in a space:
 
 ```ts
 space.cursors.on((event) => {
-    console.log(event);
+  console.log(event);
 });
 ```
 
@@ -243,7 +237,7 @@ The following is an example of subscribing to events for only a specific cursor 
 
 ```ts
 space.cursors.get('user-a-cursor').on((event) => {
-    console.log(event);
+  console.log(event);
 });
 ```
 
@@ -251,23 +245,23 @@ The following is an example `cursorUpdate` event received by subscribers when a 
 
 ```json
 {
-    "name": "user-a-cursor",
-    "connectionId": "hd9743gjDc",
-    "clientId": "clemons@slides.com",
-    "position": { "x": 864, "y": 32 },
-    "cursorData": { "color": "red" }
-  }
+  "name": "user-a-cursor",
+  "connectionId": "hd9743gjDc",
+  "clientId": "clemons@slides.com",
+  "position": { "x": 864, "y": 32 },
+  "cursorData": { "color": "red" }
+}
 ```
 
 The following are the properties of a `cursorUpdate` event:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| name | The name of the cursor. | string |
-| connectionId | The unique connection identifier for the user. | string |
-| clientId | The client identifier for the user. | string |
-| position | The x and y coordinates of the cursor. | cursorPosition |
-| data | Optional additional information about a cursor, such as its color.  | cursorData |
+| Property     | Description                                                        | Type           |
+| ------------ | ------------------------------------------------------------------ | -------------- |
+| name         | The name of the cursor.                                            | string         |
+| connectionId | The unique connection identifier for the user.                     | string         |
+| clientId     | The client identifier for the user.                                | string         |
+| position     | The x and y coordinates of the cursor.                             | cursorPosition |
+| data         | Optional additional information about a cursor, such as its color. | cursorData     |
 
 ### Request cursor locations
 
@@ -283,31 +277,31 @@ The following is an example `cursorsUpdate` received when calling `getAll()`:
 
 ```json
 {
-    "<connection-id-1>": {
-      "pointer": {
-        "name": "pointer",
-        "connectionId": "someConnectionId",
-        "clientId": "someClientId",
-        "position": { 
-            "x": 864, 
-            "y": 32 
-            },
-        "cursorData": { 
-            "color": "red" 
-            }
+  "<connection-id-1>": {
+    "pointer": {
+      "name": "pointer",
+      "connectionId": "someConnectionId",
+      "clientId": "someClientId",
+      "position": {
+        "x": 864,
+        "y": 32
+      },
+      "cursorData": {
+        "color": "red"
       }
-    },
-    "<connection-id-2>": {
-      "pointer": null
     }
+  },
+  "<connection-id-2>": {
+    "pointer": null
   }
+}
 ```
 
 The following optional properties can be passed to `getAll()`:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| name | The name of a cursor to retrieve the position for. This name is set by a user when they [create a cursor instance](#set-a-cursor-position).  | string |
+| Property | Description                                                                                                                                 | Type   |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| name     | The name of a cursor to retrieve the position for. This name is set by a user when they [create a cursor instance](#set-a-cursor-position). | string |
 
 ## Set a cursor location
 
@@ -318,17 +312,17 @@ The following is an example of creating a cursor instance and updating its locat
 ```ts
 const pointer = space.cursors.get('user-a-cursor');
 
-pointer.set({ position: { "x": clientX, "y": clientY } });
+pointer.set({ position: { x: clientX, y: clientY } });
 ```
 
 The following optional properties can be passed to `set()`:
 
-| Property | Description | Type |
-| -------- | ----------- | ---- |
-| data | Optional cursor information. ||
+| Property | Description                  | Type |
+| -------- | ---------------------------- | ---- |
+| data     | Optional cursor information. |      |
 
 The following is an example of passing `data` to the `set()` property to set the cursor color for a user:
 
 ```ts
-pointer.set({ position: { "x": clientX, "y": clientY }, data: { "color": "red" } });
+pointer.set({ position: { x: clientX, y: clientY }, data: { color: 'red' } });
 ```

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -4,11 +4,7 @@ import Space from './Space';
 import Cursor from './Cursor';
 import CursorBatching from './CursorBatching';
 import CursorDispensing from './CursorDispensing';
-import {
-  OUTGOING_BATCH_TIME_DEFAULT,
-  INCOMING_BATCH_TIME_DEFAULT,
-  PAGINATION_LIMIT_DEFAULT,
-} from './utilities/Constants';
+import { OUTGOING_BATCH_TIME_DEFAULT, PAGINATION_LIMIT_DEFAULT } from './utilities/Constants';
 import EventEmitter from './utilities/EventEmitter';
 import CursorHistory from './CursorHistory';
 import type { CursorsOptions, StrictCursorsOptions } from './options/CursorsOptions';
@@ -42,7 +38,6 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     super();
     this.options = {
       outboundBatchInterval: OUTGOING_BATCH_TIME_DEFAULT,
-      inboundBatchInterval: INCOMING_BATCH_TIME_DEFAULT,
       paginationLimit: PAGINATION_LIMIT_DEFAULT,
     };
 
@@ -53,7 +48,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     this.channel = space.client.channels.get(`${spaceChannelName}_cursors`);
     this.cursorBatching = new CursorBatching(this.channel, this.options.outboundBatchInterval);
     this.cursorHistory = new CursorHistory(this.channel, this.options.paginationLimit);
-    this.cursorDispensing = new CursorDispensing(this, this.options.inboundBatchInterval);
+    this.cursorDispensing = new CursorDispensing(this, this.cursorBatching);
   }
 
   get(name: string): Cursor {

--- a/src/options/CursorsOptions.d.ts
+++ b/src/options/CursorsOptions.d.ts
@@ -1,12 +1,10 @@
 interface CursorsOptions {
   outboundBatchInterval?: number;
-  inboundBatchInterval?: number;
   paginationLimit?: number;
 }
 
 interface StrictCursorsOptions extends CursorsOptions {
   outboundBatchInterval: number;
-  inboundBatchInterval: number;
   paginationLimit: number;
 }
 

--- a/src/utilities/math.ts
+++ b/src/utilities/math.ts
@@ -1,0 +1,5 @@
+function clamp(num, min, max) {
+  return Math.min(Math.max(num, min), max);
+}
+
+export { clamp };


### PR DESCRIPTION
This change is meant to help with cursors “stuttering”. On longer intervals, inbound intervals are dispensed a long time before a new batch comes in, creating a gap. Instead, a static option, this attempts to find a good value based on the largest current buffer. This is clamped then between 1ms and 1000/15 (60ms).

This spreads out the values up to batch time (or at least attempts to).