### PR TITLE
Updates Type for ClientOptions agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/spaces",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/spaces",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.39"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/spaces",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -33,7 +33,7 @@ type SpaceEventsMap = { membersUpdate: SpaceMember[]; leave: SpaceMember; enter:
 
 class Space extends EventEmitter<SpaceEventsMap> {
   private channelName: string;
-  private connectionId: string;
+  private connectionId: string | undefined;
   private channel: Types.RealtimeChannelPromise;
   private members: SpaceMember[];
   private leavers: SpaceLeaver[];

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -60,23 +60,23 @@ describe('Spaces', () => {
 
   it<SpacesTestContext>('applies the agent header to an existing SDK instance', ({ client }) => {
     const spaces = new Spaces(client);
-    expect((client as any).options.agents).toEqual([`ably-spaces/${spaces.version}`, 'space-custom-client']);
+    expect((client as any).options.agents).toEqual({ 'ably-spaces': spaces.version, 'space-custom-client': true });
   });
 
   it<SpacesTestContext>('applies the agent header when options are passed in', () => {
     const spaces = new Spaces(defaultClientConfig);
-    expect(spaces.ably['options'].agents).toEqual([`ably-spaces/${spaces.version}`, 'space-default-client']);
+    expect(spaces.ably['options'].agents).toEqual({ 'ably-spaces': spaces.version, 'space-default-client': true });
   });
 
   it<SpacesTestContext>('extend the agents array when it already exists', () => {
     const spaces = new Spaces({
       ...defaultClientConfig,
-      agents: ['some-client/1.2.3'],
+      agents: { 'some-client': '1.2.3' },
     } as any);
-    expect(spaces.ably['options'].agents).toEqual([
-      'some-client/1.2.3',
-      `ably-spaces/${spaces.version}`,
-      'space-default-client',
-    ]);
+    expect(spaces.ably['options'].agents).toEqual({
+      'some-client': '1.2.3',
+      'ably-spaces': spaces.version,
+      'space-default-client': true,
+    });
   });
 });

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -7,7 +7,7 @@ class Spaces {
   private channel: Types.RealtimeChannelPromise;
   ably: Types.RealtimePromise;
 
-  readonly version = '0.0.7';
+  readonly version = '0.0.8';
 
   constructor(optionsOrAbly: Types.RealtimePromise | Types.ClientOptions | string) {
     this.spaces = {};

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -23,13 +23,9 @@ class Spaces {
   }
 
   private addAgent(options: any, isDefault: boolean) {
-    const agent = `ably-spaces/${this.version}`;
-    const clientType = isDefault ? 'space-default-client' : 'space-custom-client';
-    if (!options.agents) {
-      options.agents = [agent, clientType];
-    } else if (!options.agents.includes(agent)) {
-      options.agents.push(agent, clientType);
-    }
+    const agent = { 'ably-spaces': this.version, [isDefault ? 'space-default-client' : 'space-custom-client']: true };
+
+    options.agents = { ...(options.agents ?? options.agents), ...agent };
   }
 
   async get(name: string, options?: SpaceOptions): Promise<Space> {


### PR DESCRIPTION
This PR Updates the type for ClientOptions agent which is an object, not an array.