### PR TITLE
[MMB-118] Previous location not set to null for first update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write --ignore-path .gitignore src demo",
     "format:check": "prettier --check --ignore-path .gitignore src demo",
     "test": "vitest run",
+    "watch": "vitest watch",
     "coverage": "vitest run --coverage",
     "build": "npm run build:mjs && npm run build:cjs && npm run build:iife",
     "build:mjs": "tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",

--- a/src/LocationTracker.mockClient.test.ts
+++ b/src/LocationTracker.mockClient.test.ts
@@ -2,8 +2,8 @@ import { it, describe, expect, vi, beforeEach, Mock } from 'vitest';
 import { Realtime } from 'ably/promises';
 
 import Space, { SpaceMember } from './Space.js';
-import Locations, { LocationChange } from './Locations.js';
-import LocationTracker, { LocationTrackerPredicate } from './LocationTracker.js';
+import Locations from './Locations.js';
+import LocationTracker, { LocationTrackerPredicate, LocationChange } from './LocationTracker.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 import { LOCATION_UPDATE } from './utilities/Constants.js';
 
@@ -13,7 +13,7 @@ interface LocationsTrackerTestContext {
   locations: Locations;
   spaceMember: SpaceMember;
   locationTracker: LocationTracker<{ form: string }>;
-  validEvent: LocationChange;
+  validEvent: LocationChange<{ form: string }>;
   space: Space;
   spy: Mock;
 }

--- a/src/LocationTracker.mockClient.test.ts
+++ b/src/LocationTracker.mockClient.test.ts
@@ -13,7 +13,8 @@ interface LocationsTrackerTestContext {
   locations: Locations;
   spaceMember: SpaceMember;
   locationTracker: LocationTracker<{ form: string }>;
-  validEvent: LocationChange<{ form: string }>;
+  validEvent: LocationChange;
+  space: Space;
   spy: Mock;
 }
 
@@ -75,6 +76,8 @@ describe('LocationTracker', () => {
         form: 'settings',
       },
     };
+
+    context.space = space;
   });
 
   it<LocationsTrackerTestContext>('fires when a valid location event is fired', ({
@@ -139,29 +142,34 @@ describe('LocationTracker', () => {
     expect(secondSpy).toHaveBeenCalledOnce();
   });
 
-  it<LocationsTrackerTestContext>('returns a list of only the members that are in the correct location', async ({
+  it<LocationsTrackerTestContext>('returns a list of members that are in the predicated location', async ({
     locationTracker,
     locations,
+    space,
   }) => {
     expect(locationTracker.members()).toEqual([]);
     await locations.space.enter({});
+
     locations.set({
       form: 'settings',
     });
-    expect(locationTracker.members()).toEqual([
-      {
-        clientId: 'MOCK_CLIENT_ID',
-        connectionId: '1',
-        isConnected: true,
-        lastEvent: {
-          name: 'enter',
-          timestamp: 1,
-        },
-        location: {
-          form: 'settings',
-        },
-        profileData: {},
+
+    const member = {
+      clientId: 'MOCK_CLIENT_ID',
+      connectionId: '1',
+      isConnected: true,
+      lastEvent: {
+        name: 'enter' as 'enter',
+        timestamp: 1,
       },
-    ]);
+      location: {
+        form: 'settings',
+      },
+      profileData: {},
+    };
+
+    vi.spyOn(space, 'getMembers').mockImplementationOnce(() => [member]);
+
+    expect(locationTracker.members()).toEqual([member]);
   });
 });

--- a/src/LocationTracker.ts
+++ b/src/LocationTracker.ts
@@ -3,7 +3,7 @@ import { SpaceMember } from './Space.js';
 import { LOCATION_UPDATE } from './utilities/Constants.js';
 import { EventListener } from './utilities/EventEmitter.js';
 
-type LocationChange<T> = {
+export type LocationChange<T> = {
   member: SpaceMember;
   previousLocation: unknown;
   currentLocation: T;

--- a/src/LocationTracker.ts
+++ b/src/LocationTracker.ts
@@ -1,7 +1,13 @@
-import Locations, { LocationChange } from './Locations.js';
+import Locations from './Locations.js';
 import { SpaceMember } from './Space.js';
 import { LOCATION_UPDATE } from './utilities/Constants.js';
 import { EventListener } from './utilities/EventEmitter.js';
+
+type LocationChange<T> = {
+  member: SpaceMember;
+  previousLocation: unknown;
+  currentLocation: T;
+};
 
 /**
  * Responds to a locationChange with:

--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -55,10 +55,18 @@ describe('Locations (mockClient)', () => {
       await space.enter();
       space.locations.on(LOCATION_UPDATE, spy);
       space.locations['onPresenceUpdate'](
-        createPresenceMessage('update', { clientId: '2', connectionId: '2', data: { location: 'location1' } }),
+        createPresenceMessage('update', {
+          clientId: '2',
+          connectionId: '2',
+          data: { currentLocation: 'location1', previousLocation: null },
+        }),
       );
       space.locations['onPresenceUpdate'](
-        createPresenceMessage('update', { clientId: '2', connectionId: '2', data: { location: 'location2' } }),
+        createPresenceMessage('update', {
+          clientId: '2',
+          connectionId: '2',
+          data: { currentLocation: 'location2', previousLocation: 'location1' },
+        }),
       );
       expect(spy).toHaveBeenLastCalledWith<{ member: SpaceMember; currentLocation: any; previousLocation: any }[]>({
         member: {

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -170,7 +170,7 @@ describe('Space (mockClient)', () => {
         },
       ]);
 
-      createPresenceEvent(space, 'update', { data: { profileData: { a: 1 } } });
+      createPresenceEvent(space, 'enter', { data: { profileData: { a: 1 } } });
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
         {
           clientId: '1',
@@ -178,7 +178,7 @@ describe('Space (mockClient)', () => {
           profileData: { a: 1 },
           isConnected: true,
           location: null,
-          lastEvent: { name: 'update', timestamp: 1 },
+          lastEvent: { name: 'enter', timestamp: 1 },
         },
       ]);
     });
@@ -408,12 +408,16 @@ describe('Space (mockClient)', () => {
         createPresenceEvent(space, 'enter');
 
         // Simulate a "set" location for a user
-        space.locations['onPresenceUpdate'](createPresenceMessage('update', { data: { location: '1' } }));
+        space.locations['onPresenceUpdate'](
+          createPresenceMessage('update', { data: { previousLocation: null, currentLocation: { location: '1' } } }),
+        );
 
         expect(spy).toHaveBeenCalledTimes(1);
 
         // We need to mock the message for both space & locations
-        const msg = createPresenceMessage('leave', { data: { location: '1' } });
+        const msg = createPresenceMessage('leave', {
+          data: { previousLocation: { location: '1' }, currentLocation: { location: '2' } },
+        });
         space['onPresenceUpdate'](msg);
         space.locations['onPresenceUpdate'](msg);
 

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -85,15 +85,14 @@ class Space extends EventEmitter<SpaceEventsMap> {
         connectionId: message.connectionId,
         isConnected: message.action !== 'leave',
         profileData: message.data.profileData,
-        location: null,
+        location: message?.data?.currentLocation || null,
         lastEvent,
       };
     }
 
     member.isConnected = message.action !== 'leave';
-    member.profileData = message.data?.profileData ?? member.profileData;
-    member.location = member.location ? member.location : message.data?.location ?? null;
     member.lastEvent = lastEvent;
+    member.profileData = message.data?.profileData ?? member.profileData;
 
     return member;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import Spaces from './Spaces.js';
 import Space, { type SpaceMember } from './Space.js';
-import type { LocationChange } from './Locations.js';
 
-export type { Space, LocationChange, SpaceMember };
+export type { Space, SpaceMember };
 export default Spaces;


### PR DESCRIPTION
Fix initial location being set too eagerly

This fixes a bug where both `previousLocation` and `currentLocation` would be set when .set was called initially.

When setting location, we'd get a handle on the member and update their location. However, because we called .update on the presence, the subscription on the space would trigger as well, get the location and update the member before we emit the location event.