### PR TITLE
[MMB-103]: Update avatar stack time status

### DIFF
--- a/demo/app/components/avatar-stack.ts
+++ b/demo/app/components/avatar-stack.ts
@@ -9,8 +9,10 @@ import type { SpaceMember } from '../../../src/Space';
 
 dayjs.extend(relativeTime);
 
-const updateStatusTime = (statusEl: Element, timestamp: number) =>
-  (statusEl.innerHTML = `Left ${dayjs().to(timestamp)}`);
+const updateStatusTime = (statusEl, timestamp) => {
+  const diffInSeconds = dayjs().diff(timestamp, 'second');
+  statusEl.innerHTML = `Last seen ${diffInSeconds} second${diffInSeconds === 1 ? '' : 's'} ago`;
+};
 
 const changeStatusIndicator = (fragment, isConnected, lastEvent) => {
   const statusIndicatorEl = queryDataId(fragment, 'avatar-status-indicator');


### PR DESCRIPTION
This PR changes the hover text for avatars that have left the space from 'Left a few seconds ago' to a more precise 'Last seen _n_ seconds ago'