### PR TITLE
[MMB-175] Only initialise cursors channel when .on or .set are called

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -166,7 +166,7 @@ describe('Space (mockClient)', () => {
       const spy = vi.spyOn(presence, 'subscribe');
       new Space('test', client);
       // Called by Space instantiation and by Locations instantiation
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -43,7 +43,7 @@ describe('Spaces', () => {
     const spaces = new Spaces(client);
     const space = await spaces.get('test');
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith('_ably_space_test');
     expectTypeOf(space).toMatchTypeOf<Space>();
   });


### PR DESCRIPTION
This changes the behaviour to only initialise a channel when a developer starts listening to cursor events or sets an update.