### PR TITLE
[MMB-175] Change on/off to subscribe/unsubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Space membership is used to build avatar stacks and find out which members are o
 const space = await spaces.get('demoSlideshow');
 
 // Register a listener to subscribe to events of when users enter or leave the space
-space.on('membersUpdate', (members) => {
+space.subscribe('membersUpdate', (members) => {
   console.log(members);
 });
 

--- a/demo/app/components/cursors.ts
+++ b/demo/app/components/cursors.ts
@@ -1,3 +1,4 @@
+import { Space } from '../../../src';
 import { queryDataId } from '../utils/dom';
 import type { MemberColor } from '../utils/colors';
 
@@ -45,14 +46,14 @@ const createCursor = (connectionId: string, profileData: { name: string; color: 
   return container;
 };
 
-const attachCursors = (space, slideId) => {
+const attachCursors = (space: Space, slideId) => {
   const slideContainer = document.querySelector('#slide-selected') as HTMLElement;
   const cursorContainer = queryDataId(slideContainer, 'slide-cursor-container');
   cursorContainer.innerHTML = '';
 
   const self = space.getSelf();
 
-  space.cursors.on('cursorsUpdate', (update) => {
+  space.cursors.subscribe('cursorsUpdate', (update) => {
     let cursorNode: HTMLElement = slideContainer.querySelector(`#cursor-${update.connectionId}`);
 
     const membersOnSlide = space.getMembers().filter((member) => member.location?.slide === slideId);
@@ -99,7 +100,7 @@ const attachCursors = (space, slideId) => {
   document.addEventListener('visibilitychange', cursorHandlers.tabLeft);
 
   return () => {
-    space.cursors.off();
+    space.cursors.unsubscribe();
     slideContainer.removeEventListener('mouseenter', cursorHandlers.enter);
     slideContainer.removeEventListener('mousemove', cursorHandlers.move);
     slideContainer.removeEventListener('mouseleave', cursorHandlers.leave);

--- a/demo/app/script.ts
+++ b/demo/app/script.ts
@@ -42,7 +42,7 @@ const space = await spaces.get(getSpaceNameFromUrl(), {
   offlineTimeout: 10_000,
 });
 
-space.on(MEMBERS_UPDATE, (members) => {
+space.subscribe(MEMBERS_UPDATE, (members) => {
   renderAvatars(members.filter(memberIsNotSelf));
 });
 
@@ -56,7 +56,7 @@ renderSelectedSlide(space);
 renderComments();
 let detachCursors = attachCursors(space, currentSlide().id);
 
-space.locations.on('locationUpdate', ({ previousLocation, currentLocation }) => {
+space.locations.subscribe('locationUpdate', ({ previousLocation, currentLocation }) => {
   renderSlidePreviewMenu(space);
   renderSelectedSlide(space);
 
@@ -65,7 +65,7 @@ space.locations.on('locationUpdate', ({ previousLocation, currentLocation }) => 
   detachCursors = attachCursors(space, currentSlide().id);
 });
 
-space.on('membersUpdate', (members) => {
+space.subscribe('membersUpdate', (members) => {
   renderAvatars(members.filter(memberIsNotSelf));
 });
 

--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -154,7 +154,7 @@ await space.updateProfileData((oldProfileData) => {
 })
 ```
 
-### on
+### subscribe
 
 Listen to events for the space. See [EventEmitter](/docs/usage.md#event-emitters) for overloading usage.
 
@@ -165,7 +165,7 @@ Available events:
   Listen to updates to members.
 
   ```ts
-  space.on('membersUpdate', (members: SpaceMember[]) => {});
+  space.subscribe('membersUpdate', (members: SpaceMember[]) => {});
   ```
 
   Triggers on:
@@ -178,7 +178,7 @@ Available events:
   Listen to enter events of members.
 
   ```ts
-  space.on('enter', (member: SpaceMember) => {})
+  space.subscribe('enter', (member: SpaceMember) => {})
   ```
   The argument supplied to the callback is a [SpaceMember](#spacemember) object representing the member entering the space.
 
@@ -187,7 +187,7 @@ Available events:
   Listen to leave events of members. Note that the leave event will only fire once the [offlineTimeout](#spaceoptions) has passed.
 
   ```ts
-  space.on('leave', (member: SpaceMember) => {})
+  space.subscribe('leave', (member: SpaceMember) => {})
   ```
 
   The argument supplied to the callback is a [SpaceMember](#spacemember) object representing the member leaving the space.
@@ -299,7 +299,7 @@ space.locations.getOthers()
 
 
 
-### on
+### subscribe
 
 Listen to events for locations. See [EventEmitter](/docs/usage.md#event-emitters) for overloading usage.
 
@@ -310,7 +310,7 @@ Available events:
   Fires when a member updates their location. The argument supplied to the event listener is an [LocationUpdate](#locationupdate-1).
 
   ```ts
-  space.locations.on('locationUpdate', (locationUpdate: LocationUpdate) => {});
+  space.locations.subscribe('locationUpdate', (locationUpdate: LocationUpdate) => {});
   ```
 
 ### off
@@ -381,7 +381,7 @@ Example:
 const lastPositions = space.cursors.getAll();
 ```
 
-### on
+### subscribe
 
 Listen to `CursorUpdate` events. See [EventEmitter](/docs/usage.md#event-emitters) for overloading usage.
 
@@ -392,7 +392,7 @@ Available events:
   Emits an event when a new cursor position is set. The argument supplied to the event listener is a [CursorUpdate](#cursorupdate).
 
   ```ts
-  space.cursors.on('cursorsUpdate', (cursorUpdate: CursorUpdate) => {});
+  space.cursors.subscribe('cursorsUpdate', (cursorUpdate: CursorUpdate) => {});
   ```
 
 ### off

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,12 +125,12 @@ Emitted when a member leaves a space. Called with the member leaving the space.
 Emitted when members enter, leave and their location is updated. Called with an array of all the members in the space.
 
 ```ts
-space.on('membersUpdate', (members) => {
+space.subscribe('membersUpdate', (members) => {
   console.log(members);
 });
 ```
 
-To stop listening to member events, users can call the `space.off()` method. See [Event emitters](#event-emitters) for options and usage.
+To stop listening to member events, users can call the `space.unsubscribe()` method. See [Event emitters](#event-emitters) for options and usage.
 
 ### Enter a space
 
@@ -196,7 +196,7 @@ The location property will be set on the [member](#members).
 Because locations are part of members, a `memberUpdate` event will be emitted when a member updates their location. When a member leaves, their location is set to `null`.
 
 ```ts
-space.on('membersUpdate', (members) => {
+space.subscribe('membersUpdate', (members) => {
   console.log(members);
 });
 ```
@@ -204,7 +204,7 @@ space.on('membersUpdate', (members) => {
 However, it's possible to listen to just location updates. `locations` is an [event emitter](#event-emitters) and will emit the `locationUpdate` event:
 
 ```ts
-space.locations.on('locationUpdate', (locationUpdate) => {
+space.locations.subscribe('locationUpdate', (locationUpdate) => {
   console.log(locationUpdate);
 });
 ```
@@ -247,10 +247,10 @@ A common feature of collaborative apps is to show where a users cursors is posit
 
 The most common use case is to show the current mouse pointer position.
 
-To start listing to cursor events, use the `.on` method:
+To start listing to cursor events, use the `.subscribe` method:
 
 ```ts
-space.cursors.on('cursorsUpdate', (cursorUpdate) => {
+space.cursors.subscribe('cursorsUpdate', (cursorUpdate) => {
   console.log(cursorUpdate);
 });
 ```
@@ -318,48 +318,48 @@ const lastPositions = await space.cursors.getAll();
 
 All Spaces APIs inherit from an [EventEmitter class](/src/utilities/EventEmitter.ts) and support the same event API.
 
-Calling `on` with a single function argument will subscribe to all events on that emitter.
+Calling `subscribe` with a single function argument will subscribe to all events on that emitter.
 
 ```ts
-space.on(() => {});
+space.subscribe(() => {});
 ```
 
-Calling `on` with a named event and a function argument will subscribe to that event only.
+Calling `subscribe` with a named event and a function argument will subscribe to that event only.
 
 ```ts
-space.on(`membersUpdate`, () => {});
+space.subscribe(`membersUpdate`, () => {});
 ```
 
-Calling `on` with an array of named events and a function argument will subscribe to those events.
+Calling `subscribe` with an array of named events and a function argument will subscribe to those events.
 
 ```ts
-space.on([`membersUpdate`], () => {});
+space.subscribe([`membersUpdate`], () => {});
 ```
 
-Calling `off` with no arguments will remove all registered listeners.
+Calling `unsubscribe` with no arguments will remove all registered listeners.
 
 ```ts
-space.off();
+space.unsubscribe();
 ```
 
-Calling `off` with a single named event will remove all listeners registered for that event.
+Calling `unsubscribe` with a single named event will remove all listeners registered for that event.
 
 ```ts
-space.off(`membersUpdate`);
+space.unsubscribe(`membersUpdate`);
 ```
 
-Calling `off` with an array of named events will remove all listeners registered for those events.
+Calling `unsubscribe` with an array of named events will remove all listeners registered for those events.
 
 ```ts
-space.off([`membersUpdate`]);
+space.unsubscribe([`membersUpdate`]);
 ```
 
-Calling `off` and adding a listener function as the second argument to both of the above will remove only that listener.
+Calling `unsubscribe` and adding a listener function as the second argument to both of the above will remove only that listener.
 
 ```ts
 const listener = () => {};
-space.off(`membersUpdate`, listener);
-space.off([`membersUpdate`], listener);
+space.unsubscribe(`membersUpdate`, listener);
+space.unsubscribe([`membersUpdate`], listener);
 ```
 
-As with the native DOM API, this only works if the listener is the same reference as the one passed to `on`.
+As with the native DOM API, this only works if the listener is the same reference as the one passed to `subscribe`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -316,7 +316,8 @@ const lastPositions = await space.cursors.getAll();
 
 ## Event Emitters
 
-All Spaces APIs inherit from an [EventEmitter class](/src/utilities/EventEmitter.ts) and support the same event API.
+`space`, `cursors` & `locations` are event emitters. Event emitters provide `subscribe` and `unsubscribe` methods to attach/detach event listeners. Both methods support overloaded versions, described below.
+
 
 Calling `subscribe` with a single function argument will subscribe to all events on that emitter.
 

--- a/src/Cursors.mockClient.test.ts
+++ b/src/Cursors.mockClient.test.ts
@@ -33,7 +33,7 @@ describe('Cursors (mockClient)', () => {
     context.space = new Space('test', client);
     context.cursors = context.space.cursors;
     // This will set the channel
-    context.cursors.on('cursorsUpdate', () => {});
+    context.cursors.subscribe('cursorsUpdate', () => {});
     context.channel = context.cursors['channel'] as Types.RealtimeChannelPromise;
     context.batching = context.space.cursors['cursorBatching'];
     context.dispensing = context.space.cursors['cursorDispensing'];
@@ -66,7 +66,7 @@ describe('Cursors (mockClient)', () => {
       };
 
       const spy = vitest.fn();
-      space.cursors.on(spy);
+      space.cursors.subscribe(spy);
       dispensing.processBatch(fakeMessage);
 
       vi.advanceTimersByTime(batching.batchTime * 2);

--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -43,15 +43,17 @@ describe('Locations (mockClient)', () => {
     it<SpaceTestContext>('fires an event when a location is set', async ({ space }) => {
       const spy = vi.fn();
       await space.enter();
-      space.locations.on(LOCATION_UPDATE, spy);
-      space.locations['onPresenceUpdate'](createPresenceMessage('update', { clientId: '2', connectionId: '2' }));
+      space.locations.subscribe(LOCATION_UPDATE, spy);
+      space.locations['onPresenceUpdate'](
+        createPresenceMessage('update', { clientId: '2', connectionId: '2', data: { location: 'location2' } }),
+      );
       expect(spy).toHaveBeenCalledOnce();
     });
 
     it<SpaceTestContext>('correctly sets previousLocation', async ({ space }) => {
       const spy = vi.fn();
       await space.enter();
-      space.locations.on(LOCATION_UPDATE, spy);
+      space.locations.subscribe(LOCATION_UPDATE, spy);
       space.locations['onPresenceUpdate'](
         createPresenceMessage('update', {
           clientId: '2',

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -1,7 +1,12 @@
 import { Types } from 'ably';
 
 import Space from './Space.js';
-import EventEmitter from './utilities/EventEmitter.js';
+import EventEmitter, {
+  InvalidArgumentError,
+  inspect,
+  type EventKey,
+  type EventListener,
+} from './utilities/EventEmitter.js';
 import { LOCATION_UPDATE } from './utilities/Constants.js';
 
 type LocationUpdate = typeof LOCATION_UPDATE;
@@ -37,6 +42,40 @@ export default class Locations extends EventEmitter<LocationEventMap> {
       previousLocation: self.location,
       currentLocation: location,
     });
+  }
+
+  subscribe<K extends EventKey<LocationEventMap>>(
+    listenerOrEvents?: K | K[] | EventListener<LocationEventMap[K]>,
+    listener?: EventListener<LocationEventMap[K]>,
+  ) {
+    try {
+      super.on(listenerOrEvents, listener);
+    } catch (e: unknown) {
+      if (e instanceof InvalidArgumentError) {
+        throw new InvalidArgumentError(
+          'Locations.subscribe(): Invalid arguments: ' + inspect([listenerOrEvents, listener]),
+        );
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  unsubscribe<K extends EventKey<LocationEventMap>>(
+    listenerOrEvents?: K | K[] | EventListener<LocationEventMap[K]>,
+    listener?: EventListener<LocationEventMap[K]>,
+  ) {
+    try {
+      super.off(listenerOrEvents, listener);
+    } catch (e: unknown) {
+      if (e instanceof InvalidArgumentError) {
+        throw new InvalidArgumentError(
+          'Locations.unsubscribe(): Invalid arguments: ' + inspect([listenerOrEvents, listener]),
+        );
+      } else {
+        throw e;
+      }
+    }
   }
 
   getSelf(): Location | undefined {

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -159,7 +159,7 @@ describe('Space (mockClient)', () => {
     });
   });
 
-  describe('on', () => {
+  describe('subscribe', () => {
     it('subscribes to presence updates', async () => {
       const client = new Realtime({});
       const presence = client.channels.get('').presence;
@@ -172,13 +172,13 @@ describe('Space (mockClient)', () => {
     it<SpaceTestContext>('does not include the connected client in the members result', async ({ space, client }) => {
       const spy = vi.fn();
       space['onPresenceUpdate'](createPresenceMessage('enter', { clientId: client.auth.clientId }));
-      space.on(MEMBERS_UPDATE, spy);
+      space.subscribe(MEMBERS_UPDATE, spy);
       expect(spy).not.toHaveBeenCalled();
     });
 
     it<SpaceTestContext>('adds new members', async ({ space }) => {
       const callbackSpy = vi.fn();
-      space.on(MEMBERS_UPDATE, callbackSpy);
+      space.subscribe(MEMBERS_UPDATE, callbackSpy);
 
       createPresenceEvent(space, 'enter');
 
@@ -216,7 +216,7 @@ describe('Space (mockClient)', () => {
 
     it<SpaceTestContext>('updates the data of members', async ({ space }) => {
       const callbackSpy = vi.fn();
-      space.on(MEMBERS_UPDATE, callbackSpy);
+      space.subscribe(MEMBERS_UPDATE, callbackSpy);
 
       createPresenceEvent(space, 'enter');
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
@@ -245,7 +245,7 @@ describe('Space (mockClient)', () => {
 
     it<SpaceTestContext>('updates the connected status of clients who have left', async ({ space }) => {
       const callbackSpy = vi.fn();
-      space.on(MEMBERS_UPDATE, callbackSpy);
+      space.subscribe(MEMBERS_UPDATE, callbackSpy);
 
       createPresenceEvent(space, 'enter');
       expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
@@ -274,7 +274,7 @@ describe('Space (mockClient)', () => {
 
     it<SpaceTestContext>('fires an enter message on join', async ({ space }) => {
       const callbackSpy = vi.fn();
-      space.on('enter', callbackSpy);
+      space.subscribe('enter', callbackSpy);
 
       createPresenceEvent(space, 'enter');
 
@@ -299,7 +299,7 @@ describe('Space (mockClient)', () => {
 
       it<SpaceTestContext>('removes a member who has left after the offlineTimeout', async ({ space }) => {
         const callbackSpy = vi.fn();
-        space.on(MEMBERS_UPDATE, callbackSpy);
+        space.subscribe(MEMBERS_UPDATE, callbackSpy);
 
         createPresenceEvent(space, 'enter');
         expect(callbackSpy).toHaveBeenNthCalledWith<SpaceMember[][]>(1, [
@@ -333,7 +333,7 @@ describe('Space (mockClient)', () => {
 
       it<SpaceTestContext>('sends a leave event after offlineTimeout', async ({ space }) => {
         const callbackSpy = vi.fn();
-        space.on('leave', callbackSpy);
+        space.subscribe('leave', callbackSpy);
 
         createPresenceEvent(space, 'enter');
         createPresenceEvent(space, 'leave');
@@ -352,7 +352,7 @@ describe('Space (mockClient)', () => {
 
       it<SpaceTestContext>('does not remove a member that has rejoined', async ({ space }) => {
         const callbackSpy = vi.fn();
-        space.on(MEMBERS_UPDATE, callbackSpy);
+        space.subscribe(MEMBERS_UPDATE, callbackSpy);
 
         createPresenceEvent(space, 'enter');
         createPresenceEvent(space, 'enter', { clientId: '2', connectionId: '2' });
@@ -439,21 +439,21 @@ describe('Space (mockClient)', () => {
         expect(callbackSpy).toHaveBeenCalledTimes(4);
       });
 
-      it<SpaceTestContext>('unsubscribes when off is called', async ({ space }) => {
+      it<SpaceTestContext>('unsubscribes when unsubscribe is called', async ({ space }) => {
         const spy = vi.fn();
-        space.on(MEMBERS_UPDATE, spy);
+        space.subscribe(MEMBERS_UPDATE, spy);
         createPresenceEvent(space, 'enter', { clientId: '123456' });
-        space.off(MEMBERS_UPDATE, spy);
+        space.unsubscribe(MEMBERS_UPDATE, spy);
         createPresenceEvent(space, 'enter', { clientId: '123456' });
 
         expect(spy).toHaveBeenCalledOnce();
       });
 
-      it<SpaceTestContext>('unsubscribes when off is called with no arguments', async ({ space }) => {
+      it<SpaceTestContext>('unsubscribes when unsubscribe is called with no arguments', async ({ space }) => {
         const spy = vi.fn();
-        space.on(MEMBERS_UPDATE, spy);
+        space.subscribe(MEMBERS_UPDATE, spy);
         createPresenceEvent(space, 'enter', { clientId: '123456' });
-        space.off();
+        space.unsubscribe();
         createPresenceEvent(space, 'enter', { clientId: '123456' });
 
         expect(spy).toHaveBeenCalledOnce();

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -1,7 +1,12 @@
 import { Types } from 'ably';
 
 import SpaceOptions from './options/SpaceOptions.js';
-import EventEmitter from './utilities/EventEmitter.js';
+import EventEmitter, {
+  InvalidArgumentError,
+  inspect,
+  type EventKey,
+  type EventListener,
+} from './utilities/EventEmitter.js';
 import Locations from './Locations.js';
 import Cursors from './Cursors.js';
 
@@ -227,6 +232,40 @@ class Space extends EventEmitter<SpaceEventsMap> {
     }
 
     return;
+  }
+
+  subscribe<K extends EventKey<SpaceEventsMap>>(
+    listenerOrEvents?: K | K[] | EventListener<SpaceEventsMap[K]>,
+    listener?: EventListener<SpaceEventsMap[K]>,
+  ) {
+    try {
+      super.on(listenerOrEvents, listener);
+    } catch (e: unknown) {
+      if (e instanceof InvalidArgumentError) {
+        throw new InvalidArgumentError(
+          'Space.subscribe(): Invalid arguments: ' + inspect([listenerOrEvents, listener]),
+        );
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  unsubscribe<K extends EventKey<SpaceEventsMap>>(
+    listenerOrEvents?: K | K[] | EventListener<SpaceEventsMap[K]>,
+    listener?: EventListener<SpaceEventsMap[K]>,
+  ) {
+    try {
+      super.off(listenerOrEvents, listener);
+    } catch (e: unknown) {
+      if (e instanceof InvalidArgumentError) {
+        throw new InvalidArgumentError(
+          'Space.unsubscribe(): Invalid arguments: ' + inspect([listenerOrEvents, listener]),
+        );
+      } else {
+        throw e;
+      }
+    }
   }
 }
 

--- a/src/utilities/EventEmitter.test.ts
+++ b/src/utilities/EventEmitter.test.ts
@@ -96,29 +96,29 @@ describe('EventEmitter', () => {
     });
 
     it('adds a listener to the "any" set of event listeners', (context) => {
-      context.eventEmitter.on(context.spy);
-      expect(context.eventEmitter.any).toStrictEqual([context.spy]);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['on'](context.spy);
+      expect(context.eventEmitter['any']).toStrictEqual([context.spy]);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
     });
 
     it('adds a listener to a provided field of an event listener', (context) => {
-      context.eventEmitter.on('myEvent', context.spy);
-      expect(context.eventEmitter.events['myEvent']).toStrictEqual([context.spy]);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['on']('myEvent', context.spy);
+      expect(context.eventEmitter['events']['myEvent']).toStrictEqual([context.spy]);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
     });
 
     it('adds a listener to all provided fields of an event listener', (context) => {
-      context.eventEmitter.on(['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
-      expect(context.eventEmitter.events['myEvent']).toStrictEqual([context.spy]);
-      expect(context.eventEmitter.events['myOtherEvent']).toStrictEqual([context.spy]);
-      expect(context.eventEmitter.events['myThirdEvent']).toStrictEqual([context.spy]);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['on'](['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
+      expect(context.eventEmitter['events']['myEvent']).toStrictEqual([context.spy]);
+      expect(context.eventEmitter['events']['myOtherEvent']).toStrictEqual([context.spy]);
+      expect(context.eventEmitter['events']['myThirdEvent']).toStrictEqual([context.spy]);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledTimes(1);
-      context.eventEmitter.emit('myOtherEvent');
+      context.eventEmitter['emit']('myOtherEvent');
       expect(context.spy).toHaveBeenCalledTimes(2);
-      context.eventEmitter.emit('myThirdEvent');
+      context.eventEmitter['emit']('myThirdEvent');
       expect(context.spy).toHaveBeenCalledTimes(3);
     });
   });
@@ -128,79 +128,79 @@ describe('EventEmitter', () => {
       context.spy = vi.fn();
       const eventEmitter: EventEmitter<{ myEvent: string; myOtherEvent: string; myThirdEvent: string }> =
         new EventEmitter();
-      eventEmitter.on(context.spy);
-      eventEmitter.on(altListener);
-      eventEmitter.on('myEvent', context.spy);
-      eventEmitter.on(['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
-      eventEmitter.on('myEvent', altListener);
-      eventEmitter.on(['myEvent', 'myOtherEvent', 'myThirdEvent'], altListener);
-      eventEmitter.once(context.spy);
-      eventEmitter.once(altListener);
-      eventEmitter.once('myEvent', context.spy);
-      eventEmitter.once('myEvent', altListener);
-      eventEmitter.once(['myEvent', 'myOtherEvent', 'myThirdEvent'], altListener);
+      eventEmitter['on'](context.spy);
+      eventEmitter['on'](altListener);
+      eventEmitter['on']('myEvent', context.spy);
+      eventEmitter['on'](['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
+      eventEmitter['on']('myEvent', altListener);
+      eventEmitter['on'](['myEvent', 'myOtherEvent', 'myThirdEvent'], altListener);
+      eventEmitter['once'](context.spy);
+      eventEmitter['once'](altListener);
+      eventEmitter['once']('myEvent', context.spy);
+      eventEmitter['once']('myEvent', altListener);
+      eventEmitter['once'](['myEvent', 'myOtherEvent', 'myThirdEvent'], altListener);
       context.eventEmitter = eventEmitter;
     });
 
     it('removes all listeners from all event queues', (context) => {
-      context.eventEmitter.off();
-      expect(context.eventEmitter.any).toStrictEqual([]);
-      expect(context.eventEmitter.anyOnce).toStrictEqual([]);
-      expect(context.eventEmitter.events).toStrictEqual(Object.create(null));
-      expect(context.eventEmitter.eventsOnce).toStrictEqual(Object.create(null));
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['off']();
+      expect(context.eventEmitter['any']).toStrictEqual([]);
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([]);
+      expect(context.eventEmitter['events']).toStrictEqual(Object.create(null));
+      expect(context.eventEmitter['eventsOnce']).toStrictEqual(Object.create(null));
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).not.toHaveBeenCalled();
     });
 
     it('removes one listener from all lists', (context) => {
-      context.eventEmitter.off(context.spy);
-      expect(context.eventEmitter.any).toStrictEqual([altListener]);
-      expect(context.eventEmitter.anyOnce).toStrictEqual([altListener]);
-      expect(context.eventEmitter.events['myEvent']).not.toContain(context.spy);
-      expect(context.eventEmitter.eventsOnce['myEvent']).not.toContain(context.spy);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['off'](context.spy);
+      expect(context.eventEmitter['any']).toStrictEqual([altListener]);
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([altListener]);
+      expect(context.eventEmitter['events']['myEvent']).not.toContain(context.spy);
+      expect(context.eventEmitter['eventsOnce']['myEvent']).not.toContain(context.spy);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).not.toHaveBeenCalled();
     });
 
     it('removes a specific listener from one event', (context) => {
-      context.eventEmitter.off('myEvent', context.spy);
-      expect(context.eventEmitter.any).toStrictEqual([context.spy, altListener]);
-      expect(context.eventEmitter.anyOnce).toStrictEqual([context.spy, altListener]);
-      expect(context.eventEmitter.events['myEvent']).not.toContain(context.spy);
-      expect(context.eventEmitter.events['myOtherEvent']).toContain(context.spy);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['off']('myEvent', context.spy);
+      expect(context.eventEmitter['any']).toStrictEqual([context.spy, altListener]);
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([context.spy, altListener]);
+      expect(context.eventEmitter['events']['myEvent']).not.toContain(context.spy);
+      expect(context.eventEmitter['events']['myOtherEvent']).toContain(context.spy);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledTimes(2);
-      context.eventEmitter.emit('myOtherEvent');
+      context.eventEmitter['emit']('myOtherEvent');
       expect(context.spy).toHaveBeenCalledTimes(3);
     });
 
     it('removes a specific listener from multiple events', () => {
       const eventEmitter = new EventEmitter();
       const specificListener = vi.fn();
-      eventEmitter.on(['myEvent', 'myOtherEvent', 'myThirdEvent'], specificListener);
-      eventEmitter.off(['myEvent', 'myOtherEvent'], specificListener);
-      expect(eventEmitter.events['myEvent']).toBe(undefined);
-      expect(eventEmitter.events['myOtherEvent']).toBe(undefined);
-      expect(eventEmitter.events['myThirdEvent']).toContain(specificListener);
-      eventEmitter.emit('myEvent');
-      eventEmitter.emit('myOtherEvent');
+      eventEmitter['on'](['myEvent', 'myOtherEvent', 'myThirdEvent'], specificListener);
+      eventEmitter['off'](['myEvent', 'myOtherEvent'], specificListener);
+      expect(eventEmitter['events']['myEvent']).toBe(undefined);
+      expect(eventEmitter['events']['myOtherEvent']).toBe(undefined);
+      expect(eventEmitter['events']['myThirdEvent']).toContain(specificListener);
+      eventEmitter['emit']('myEvent');
+      eventEmitter['emit']('myOtherEvent');
       expect(specificListener).not.toHaveBeenCalled();
-      expect(eventEmitter.events['myThirdEvent']).toContain(specificListener);
-      eventEmitter.emit('myThirdEvent');
+      expect(eventEmitter['events']['myThirdEvent']).toContain(specificListener);
+      eventEmitter['emit']('myThirdEvent');
       expect(specificListener).toHaveBeenCalledOnce();
     });
 
     it('removes all listeners from an event', (context) => {
-      context.eventEmitter.off('myEvent');
-      expect(context.eventEmitter.events['myEvent']).toBe(undefined);
-      expect(context.eventEmitter.events['myOtherEvent']).toContain(context.spy);
+      context.eventEmitter['off']('myEvent');
+      expect(context.eventEmitter['events']['myEvent']).toBe(undefined);
+      expect(context.eventEmitter['events']['myOtherEvent']).toContain(context.spy);
     });
 
     it('removes all listeners from multiple events', (context) => {
-      context.eventEmitter.off(['myEvent', 'myOtherEvent']);
-      expect(context.eventEmitter.events['myEvent']).toBe(undefined);
-      expect(context.eventEmitter.events['myOtherEvent']).toBe(undefined);
-      expect(context.eventEmitter.events['myThirdEvent']).toContain(context.spy);
+      context.eventEmitter['off'](['myEvent', 'myOtherEvent']);
+      expect(context.eventEmitter['events']['myEvent']).toBe(undefined);
+      expect(context.eventEmitter['events']['myOtherEvent']).toBe(undefined);
+      expect(context.eventEmitter['events']['myThirdEvent']).toContain(context.spy);
     });
   });
 
@@ -208,23 +208,23 @@ describe('EventEmitter', () => {
     beforeEach(async (context) => {
       const eventEmitter: EventEmitter<{ myEvent: string; myOtherEvent: string; myThirdEvent: string }> =
         new EventEmitter();
-      eventEmitter.on(listener);
-      eventEmitter.on(altListener);
-      eventEmitter.on('myEvent', listener);
-      eventEmitter.once(listener);
-      eventEmitter.once(altListener);
-      eventEmitter.once('myEvent', listener);
-      eventEmitter.once('myEvent', altListener);
+      eventEmitter['on'](listener);
+      eventEmitter['on'](altListener);
+      eventEmitter['on']('myEvent', listener);
+      eventEmitter['once'](listener);
+      eventEmitter['once'](altListener);
+      eventEmitter['once']('myEvent', listener);
+      eventEmitter['once']('myEvent', altListener);
       context.eventEmitter = eventEmitter;
     });
 
     it('returns all listeners for a given event', (context) => {
-      expect(context.eventEmitter.listeners('myEvent')).toHaveLength(3);
-      expect(context.eventEmitter.listeners('myOtherEvent')).toBe(null);
-      context.eventEmitter.on('myEvent', listener);
-      expect(context.eventEmitter.listeners('myEvent')).toHaveLength(4);
-      context.eventEmitter.once('myEvent', listener);
-      expect(context.eventEmitter.listeners('myEvent')).toHaveLength(5);
+      expect(context.eventEmitter['listeners']('myEvent')).toHaveLength(3);
+      expect(context.eventEmitter['listeners']('myOtherEvent')).toBe(null);
+      context.eventEmitter['on']('myEvent', listener);
+      expect(context.eventEmitter['listeners']('myEvent')).toHaveLength(4);
+      context.eventEmitter['once']('myEvent', listener);
+      expect(context.eventEmitter['listeners']('myEvent')).toHaveLength(5);
     });
   });
 
@@ -235,35 +235,35 @@ describe('EventEmitter', () => {
     });
 
     it('responds to an emit event when calling `once` without any parameters', (context) => {
-      expect(context.eventEmitter.once).toThrowError('invalid arguments:[null,null]');
+      expect(context.eventEmitter['once']).toThrowError('invalid arguments:[null,null]');
     });
 
     it('adds a listener to anyOnce on calling `once` with a listener', (context) => {
-      context.eventEmitter.once(context.spy);
-      expect(context.eventEmitter.anyOnce).toHaveLength(1);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['once'](context.spy);
+      expect(context.eventEmitter['anyOnce']).toHaveLength(1);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
-      context.eventEmitter.emit('myOtherEvent');
+      context.eventEmitter['emit']('myOtherEvent');
     });
 
     it('adds a listener to an eventOnce on calling `once` with a listener and event name', (context) => {
-      context.eventEmitter.once('myEvent', context.spy);
-      expect(context.eventEmitter.eventsOnce['myEvent']).toHaveLength(1);
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['once']('myEvent', context.spy);
+      expect(context.eventEmitter['eventsOnce']['myEvent']).toHaveLength(1);
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
     });
 
     it('adds a listener to multiple eventOnce fields on calling `once` with a listener and event name; and after emitting any of the events, all are removed', (context) => {
-      context.eventEmitter.once(['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
-      expect(context.eventEmitter.eventsOnce['myEvent']).toHaveLength(1);
-      expect(context.eventEmitter.eventsOnce['myOtherEvent']).toHaveLength(1);
-      expect(context.eventEmitter.eventsOnce['myThirdEvent']).toHaveLength(1);
-      expect(context.eventEmitter.emit('myEvent'));
-      expect(context.eventEmitter.eventsOnce['myEvent']).toBe(undefined);
-      expect(context.eventEmitter.eventsOnce['myOtherEvent']).toBe(undefined);
-      expect(context.eventEmitter.eventsOnce['myThirdEvent']).toBe(undefined);
+      context.eventEmitter['once'](['myEvent', 'myOtherEvent', 'myThirdEvent'], context.spy);
+      expect(context.eventEmitter['eventsOnce']['myEvent']).toHaveLength(1);
+      expect(context.eventEmitter['eventsOnce']['myOtherEvent']).toHaveLength(1);
+      expect(context.eventEmitter['eventsOnce']['myThirdEvent']).toHaveLength(1);
+      expect(context.eventEmitter['emit']('myEvent'));
+      expect(context.eventEmitter['eventsOnce']['myEvent']).toBe(undefined);
+      expect(context.eventEmitter['eventsOnce']['myOtherEvent']).toBe(undefined);
+      expect(context.eventEmitter['eventsOnce']['myThirdEvent']).toBe(undefined);
       expect(context.spy).toHaveBeenCalledOnce();
     });
   });
@@ -272,32 +272,32 @@ describe('EventEmitter', () => {
     beforeEach(async (context) => {
       context.eventEmitter = new EventEmitter();
       context.spy = vi.fn();
-      context.eventEmitter.once(listener);
+      context.eventEmitter['once'](listener);
     });
 
     it('emits an event on being called', (context) => {
-      context.eventEmitter.on('myEvent', context.spy);
-      expect(context.eventEmitter.listeners('myEvent')).toContain(context.spy);
+      context.eventEmitter['on']('myEvent', context.spy);
+      expect(context.eventEmitter['listeners']('myEvent')).toContain(context.spy);
       expect(context.spy).not.toHaveBeenCalled();
-      context.eventEmitter.emit('myEvent');
+      context.eventEmitter['emit']('myEvent');
       expect(context.spy).toHaveBeenCalledOnce();
       // anyOnce must also be emptied
-      expect(context.eventEmitter.anyOnce).toStrictEqual([]);
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([]);
     });
 
     it('emits any events in anyOnce on emitting specific events', (context) => {
-      context.eventEmitter.on('myEvent', context.spy);
-      context.eventEmitter.emit('myEvent');
-      expect(context.eventEmitter.anyOnce).toStrictEqual([]);
+      context.eventEmitter['on']('myEvent', context.spy);
+      context.eventEmitter['emit']('myEvent');
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([]);
       expect(context.spy).toHaveBeenCalledOnce();
     });
 
     it('emits an event and removes it on being called for a once operation', (context) => {
-      context.eventEmitter.once('myEvent', context.spy);
-      expect(context.eventEmitter.listeners('myEvent')).toContain(context.spy);
-      context.eventEmitter.emit('myEvent');
-      expect(context.eventEmitter.listeners('myEvent')).toBe(null);
-      expect(context.eventEmitter.anyOnce).toStrictEqual([]);
+      context.eventEmitter['once']('myEvent', context.spy);
+      expect(context.eventEmitter['listeners']('myEvent')).toContain(context.spy);
+      context.eventEmitter['emit']('myEvent');
+      expect(context.eventEmitter['listeners']('myEvent')).toBe(null);
+      expect(context.eventEmitter['anyOnce']).toStrictEqual([]);
       expect(context.spy).toHaveBeenCalledOnce();
     });
   });

--- a/src/utilities/EventEmitter.ts
+++ b/src/utilities/EventEmitter.ts
@@ -69,10 +69,10 @@ export type EventKey<T extends EventMap> = string & keyof T;
 export type EventListener<T> = (params: T) => void;
 
 export default class EventEmitter<T extends EventMap> {
-  any: Array<Function>;
-  events: Record<string, Function[]>;
-  anyOnce: Array<Function>;
-  eventsOnce: Record<string, Function[]>;
+  protected any: Array<Function>;
+  protected events: Record<string, Function[]>;
+  protected anyOnce: Array<Function>;
+  protected eventsOnce: Record<string, Function[]>;
 
   constructor() {
     this.any = [];
@@ -86,7 +86,10 @@ export default class EventEmitter<T extends EventMap> {
    * @param listenerOrEvents (optional) the name of the event to listen to or the listener to be called.
    * @param listener (optional) the listener to be called.
    */
-  on<K extends EventKey<T>>(listenerOrEvents?: K | K[] | EventListener<T[K]>, listener?: EventListener<T[K]>): void {
+  protected on<K extends EventKey<T>>(
+    listenerOrEvents?: K | K[] | EventListener<T[K]>,
+    listener?: EventListener<T[K]>,
+  ): void {
     // .on(() => {})
     if (isFunction(listenerOrEvents)) {
       this.any.push(listenerOrEvents);
@@ -117,7 +120,10 @@ export default class EventEmitter<T extends EventMap> {
    * the listener is treated as an 'any' listener.
    * @param listener (optional) the listener to remove. If not supplied, all listeners are removed.
    */
-  off<K extends EventKey<T>>(listenerOrEvents?: K | K[] | EventListener<T[K]>, listener?: EventListener<T[K]>): void {
+  protected off<K extends EventKey<T>>(
+    listenerOrEvents?: K | K[] | EventListener<T[K]>,
+    listener?: EventListener<T[K]>,
+  ): void {
     // .off()
     // don't use arguments.length === 0 here as don't won't handle
     // cases like .off(undefined) which is a valid call
@@ -172,7 +178,7 @@ export default class EventEmitter<T extends EventMap> {
    * @param event (optional) the name of the event, or none for 'any'
    * @return array of events, or null if none
    */
-  listeners<K extends EventKey<T>>(event: K): Function[] | null {
+  protected listeners<K extends EventKey<T>>(event: K): Function[] | null {
     if (event) {
       const listeners = [...(this.events[event] ?? [])];
 
@@ -225,7 +231,7 @@ export default class EventEmitter<T extends EventMap> {
    * @param listenerOrEvents (optional) the name of the event to listen to
    * @param listener (optional) the listener to be called
    */
-  once<K extends EventKey<T>>(
+  protected once<K extends EventKey<T>>(
     listenerOrEvents: K | K[] | EventListener<T[K]>,
     listener?: EventListener<T[K]>,
   ): void | Promise<any> {
@@ -271,7 +277,12 @@ export default class EventEmitter<T extends EventMap> {
    * @param listener the listener to be called
    * @param listenerArgs
    */
-  whenState(targetState: string, currentState: string, listener: EventListener<T>, ...listenerArgs: unknown[]) {
+  protected whenState(
+    targetState: string,
+    currentState: string,
+    listener: EventListener<T>,
+    ...listenerArgs: unknown[]
+  ) {
     const eventThis = { event: targetState };
 
     if (typeof targetState !== 'string' || typeof currentState !== 'string') {

--- a/src/utilities/EventEmitter.ts
+++ b/src/utilities/EventEmitter.ts
@@ -53,13 +53,19 @@ export function removeListener(
 }
 
 // Equivalent of Platform.config.inspect from ably-js for browser/RN
-function inspect(args: any): string {
+export function inspect(args: unknown): string {
   return JSON.stringify(args);
+}
+
+export class InvalidArgumentError extends Error {
+  constructor(...args) {
+    super(...args);
+  }
 }
 
 type EventMap = Record<string, any>;
 // extract all the keys of an event map and use them as a type
-type EventKey<T extends EventMap> = string & keyof T;
+export type EventKey<T extends EventMap> = string & keyof T;
 export type EventListener<T> = (params: T) => void;
 
 export default class EventEmitter<T extends EventMap> {
@@ -102,7 +108,7 @@ export default class EventEmitter<T extends EventMap> {
       return;
     }
 
-    throw new Error('EventEmitter.on(): Invalid arguments: ' + inspect([listenerOrEvents, listener]));
+    throw new InvalidArgumentError('EventEmitter.on(): Invalid arguments: ' + inspect([listenerOrEvents, listener]));
   }
 
   /**
@@ -113,7 +119,9 @@ export default class EventEmitter<T extends EventMap> {
    */
   off<K extends EventKey<T>>(listenerOrEvents?: K | K[] | EventListener<T[K]>, listener?: EventListener<T[K]>): void {
     // .off()
-    if (arguments.length === 0) {
+    // don't use arguments.length === 0 here as don't won't handle
+    // cases like .off(undefined) which is a valid call
+    if (!listenerOrEvents && !listener) {
       this.any = [];
       this.events = Object.create(null);
       this.anyOnce = [];
@@ -156,7 +164,7 @@ export default class EventEmitter<T extends EventMap> {
       return;
     }
 
-    throw new Error('EventEmitter.off(): invalid arguments:' + inspect([listenerOrEvents, listener]));
+    throw new InvalidArgumentError('EventEmitter.off(): invalid arguments:' + inspect([listenerOrEvents, listener]));
   }
 
   /**
@@ -251,7 +259,7 @@ export default class EventEmitter<T extends EventMap> {
       return;
     }
 
-    throw new Error('EventEmitter.once(): invalid arguments:' + inspect([listenerOrEvents, listener]));
+    throw new InvalidArgumentError('EventEmitter.once(): invalid arguments:' + inspect([listenerOrEvents, listener]));
   }
 
   /**


### PR DESCRIPTION
This is done not by updating the names in the EventEmitter, but by proxying the methods in classes. We'd like to keep the API of that class as close as possible to the ably-js one.

Furthermore, we'd like to reserve .on/off for potential, future connection events.