### PR TITLE
[MMB-180] Add getSelf and getOthers method to cursors

### DIFF
--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -381,6 +381,34 @@ Example:
 const lastPositions = space.cursors.getAll();
 ```
 
+### getSelf
+
+Get the last CursorUpdate for self.
+
+```ts
+type getSelf = () => <CursorUpdate | undefined>;
+```
+
+Example:
+
+```ts
+const selfPosition = space.cursors.getSelf();
+```
+
+### getOthers
+
+Get the last CursorUpdate for each connection.
+
+```ts
+type getOthers = () => Record<ConnectionId, CursorUpdate>;
+```
+
+Example:
+
+```ts
+const otherPositions = space.cursors.getOthers();
+```
+
 ### subscribe
 
 Listen to `CursorUpdate` events. See [EventEmitter](/docs/usage.md#event-emitters) for overloading usage.

--- a/src/CursorHistory.ts
+++ b/src/CursorHistory.ts
@@ -3,11 +3,8 @@ import { Types } from 'ably';
 import type { CursorUpdate } from './Cursors.js';
 import type { StrictCursorsOptions } from './options/CursorsOptions.js';
 
-type LastPosition = null | CursorUpdate;
-type CursorName = string;
-type CursorsLastPostion = Record<CursorName, LastPosition>;
 type ConnectionId = string;
-type ConnectionsLastPosition = Record<ConnectionId, null | CursorUpdate | CursorsLastPostion>;
+type ConnectionsLastPosition = Record<ConnectionId, null | CursorUpdate>;
 
 export default class CursorHistory {
   constructor() {}


### PR DESCRIPTION
This PR adds the following methods to the Cursors:
- `getSelf`
- `getOthers`

Also fixes a typo for `LastPosition`