### PR TITLE
space: Fix clobbering presence data

### DIFF
--- a/src/Locations.mockClient.test.ts
+++ b/src/Locations.mockClient.test.ts
@@ -38,6 +38,23 @@ describe('Locations (mockClient)', () => {
       await space.enter();
       space.locations.set('location1');
       expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith({
+        profileData: {},
+        currentLocation: 'location1',
+      });
+    });
+
+    it<SpaceTestContext>('sets previousLocation after setting location multiple times', async ({ space, presence }) => {
+      const spy = vi.spyOn(presence, 'update');
+      await space.enter();
+      space.locations.set('location1');
+      space.locations.set('location2');
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenNthCalledWith(2, {
+        profileData: {},
+        previousLocation: 'location1',
+        currentLocation: 'location2',
+      });
     });
 
     it<SpaceTestContext>('fires an event when a location is set', async ({ space }) => {

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -37,11 +37,10 @@ export default class Locations extends EventEmitter<LocationEventMap> {
       throw new Error('Must enter a space before setting a location');
     }
 
-    return this.channel.presence.update({
-      profileData: self.profileData,
-      previousLocation: self.location,
-      currentLocation: location,
-    });
+    self.previousLocation = self.location;
+    self.location = location;
+
+    return this.space.updateSelf(self);
   }
 
   subscribe<K extends EventKey<LocationEventMap>>(

--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -148,6 +148,34 @@ describe('Space (mockClient)', () => {
         await space.updateProfileData((profileData) => ({ ...profileData, a: 2 }));
         expect(updateSpy).toHaveBeenNthCalledWith(1, { profileData: { a: 2 } });
       });
+
+      it<SpaceTestContext>('maintains the members location in presence data', async ({ presence, space }) => {
+        const spy = vi.spyOn(presence, 'update');
+        vi.spyOn(space, 'getSelf').mockReturnValue({
+          clientId: '1',
+          connectionId: 'testConnectionId',
+          isConnected: true,
+          location: null,
+          lastEvent: {
+            name: 'enter',
+            timestamp: 1,
+          },
+          profileData: {
+            a: 1,
+          },
+        });
+        await space.locations.set('location1');
+        await space.updateProfileData({ a: 2 });
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenNthCalledWith(1, {
+          profileData: { a: 1 },
+          currentLocation: 'location1',
+        });
+        expect(spy).toHaveBeenNthCalledWith(2, {
+          profileData: { a: 2 },
+          currentLocation: 'location1',
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Before this commit, `space.updateProfileData` would call `presence.update` with just the updated profile data, removing the previous and current locations that might be set in the presence data.

This commit fixes the issue by introducing an `updateSelf` function which allows callers to mutate the member retrieved from `getSelf` and trigger a presence update which maintains unrelated fields within the resulting presence data.