### PR TITLE
Add Component Locking

### DIFF
--- a/__mocks__/ably/promises/index.ts
+++ b/__mocks__/ably/promises/index.ts
@@ -1,4 +1,4 @@
-import { Types } from 'ably/promises';
+import Ably, { Types } from 'ably/promises';
 
 const MOCK_CLIENT_ID = 'MOCK_CLIENT_ID';
 
@@ -71,5 +71,9 @@ class MockRealtime {
     this['options'] = {};
   }
 }
+
+// maintain the PresenceMessage class so tests can initialise it directly using
+// PresenceMessage.fromValues.
+MockRealtime.PresenceMessage = Ably.Rest.PresenceMessage;
 
 export { MockRealtime as Realtime };

--- a/examples/locks.ts
+++ b/examples/locks.ts
@@ -1,0 +1,93 @@
+// An example of members locating at and locking elements in a slides
+// application.
+import Ably from 'ably/promises';
+import Spaces from '../dist/cjs/Spaces.js';
+import { Lock } from '../dist/cjs/Locks.js';
+
+// SlideElement represents an element on a slide which a member can both be
+// located at and attempt to lock (e.g. an editable text box).
+class SlideElement {
+  slideId: string;
+  elementId: string;
+
+  constructor(slideId: string, elementId: string) {
+    this.slideId = slideId;
+    this.elementId = elementId;
+  }
+
+  // the identifier to use to lock this SlideElement.
+  lockId(): string {
+    return `/slides/${this.slideId}/element/${this.elementId}`;
+  }
+
+  // the attributes to use when locking this SlideElement.
+  lockAttributes(): Map<string, string> {
+    const attributes = new Map();
+    attributes.set('slideId', this.slideId);
+    attributes.set('elementId', this.elementId);
+    return attributes;
+  }
+}
+
+// define a main async function since we can't use await at the top-level.
+const main = async () => {
+  info('initialising Ably client');
+  const client = new Ably.Realtime.Promise({
+    key: process.env.ABLY_API_KEY,
+    clientId: 'Alice',
+  });
+
+  info('entering the "example" space');
+  const spaces = new Spaces(client);
+  const space = await spaces.get('example');
+  await space.enter();
+
+  const location = new SlideElement('123', '456');
+  info(`setting location to ${JSON.stringify(location)}`);
+  await space.locations.set(location);
+
+  info('checking if location is locked');
+  const lockId = location.lockId();
+  const isLocked = space.locks.get(lockId) !== undefined;
+  if (isLocked) {
+    info('location is already locked');
+    process.exit();
+  } else {
+    info('location is not locked');
+  }
+
+  // initialise a Promise which resolves when the lock changes status.
+  const lockEvent = new Promise<Lock>((resolve) => {
+    const listener = (lock: Lock) => {
+      if (lock.request.id === lockId) {
+        info(`received lock update for "${lockId}", status=${lock.request.status}`);
+        resolve(lock);
+        info('unsubscribing from lock events');
+        space.locks.unsubscribe(listener);
+      }
+    };
+    info('subscribing to lock events');
+    space.locks.subscribe('update', listener);
+  });
+
+  info(`attempting to lock "${lockId}"`);
+  const req = await space.locks.acquire(lockId, { attributes: location.lockAttributes() });
+  info(`lock status is "${req.status}"`);
+
+  info('waiting for lock event');
+  const lock = await lockEvent;
+
+  info(`lock status is "${lock.request.status}"`);
+
+  info('releasing the lock');
+  await space.locks.release(lockId);
+
+  info('done');
+  client.close();
+};
+
+const info = (msg: string) => {
+  console.log(new Date(), 'INFO', msg);
+}
+
+main();

--- a/examples/locks.ts
+++ b/examples/locks.ts
@@ -2,7 +2,7 @@
 // application.
 import Ably from 'ably/promises';
 import Spaces from '../dist/cjs/Spaces.js';
-import { Lock } from '../dist/cjs/Locks.js';
+import { Lock, LockAttributes } from '../dist/cjs/Locks.js';
 
 // SlideElement represents an element on a slide which a member can both be
 // located at and attempt to lock (e.g. an editable text box).
@@ -21,8 +21,8 @@ class SlideElement {
   }
 
   // the attributes to use when locking this SlideElement.
-  lockAttributes(): Map<string, string> {
-    const attributes = new Map();
+  lockAttributes(): LockAttributes {
+    const attributes = new LockAttributes();
     attributes.set('slideId', this.slideId);
     attributes.set('elementId', this.elementId);
     return attributes;

--- a/examples/locks.ts
+++ b/examples/locks.ts
@@ -2,7 +2,7 @@
 // application.
 import Ably from 'ably/promises';
 import Spaces from '../dist/cjs/Spaces.js';
-import { Lock, LockAttributes } from '../dist/cjs/Locks.js';
+import { Lock, LockAttributes } from '../dist/cjs/index.js';
 
 // SlideElement represents an element on a slide which a member can both be
 // located at and attempt to lock (e.g. an editable text box).

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "mock-socket": "^9.1.5",
         "prettier": "^2.8.3",
         "rollup": "^3.28.0",
+        "ts-node": "^10.9.1",
         "typescript": "^4.9.5",
         "vitest": "^0.29.8"
       }
@@ -41,6 +42,28 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.36.1",
@@ -594,6 +617,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -1133,6 +1180,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1551,6 +1604,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "node_modules/cross-spawn": {
@@ -3208,6 +3267,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4276,6 +4341,58 @@
       "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
       "integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -4398,6 +4515,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -4718,6 +4841,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
@@ -4745,6 +4877,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@es-joy/jsdoccomment": {
       "version": "0.36.1",
@@ -5050,6 +5203,30 @@
       "requires": {
         "defer-to-connect": "^2.0.0"
       }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "@types/cacheable-request": {
       "version": "6.0.3",
@@ -5431,6 +5608,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5746,6 +5929,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-spawn": {
@@ -6975,6 +7164,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7707,6 +7902,35 @@
       "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
       "integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7798,6 +8022,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -7983,6 +8213,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.12",
       "license": "ISC",
       "dependencies": {
-        "ably": "^1.2.42",
+        "ably": "^1.2.43",
         "nanoid": "^4.0.2"
       },
       "devDependencies": {
@@ -1051,9 +1051,9 @@
       }
     },
     "node_modules/ably": {
-      "version": "1.2.42",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.42.tgz",
-      "integrity": "sha512-dUnza7cERLWaDa/2pLVXtU2PJoU5k/t6g9sQZI1dgWC5Vok39nE6tf/xH2Rat7PJs7pXl9hLpkg1AhS4Xwd2/w==",
+      "version": "1.2.43",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.43.tgz",
+      "integrity": "sha512-HZ99Nd98KzYToNUD4+ysHp4+vMp1NmYTi59yqGpejHo/VffTgg0pereoib0nRRAHYUhGUGys5HGwR5yHYESWDA==",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "got": "^11.8.5",
@@ -5376,9 +5376,9 @@
       }
     },
     "ably": {
-      "version": "1.2.42",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.42.tgz",
-      "integrity": "sha512-dUnza7cERLWaDa/2pLVXtU2PJoU5k/t6g9sQZI1dgWC5Vok39nE6tf/xH2Rat7PJs7pXl9hLpkg1AhS4Xwd2/w==",
+      "version": "1.2.43",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.43.tgz",
+      "integrity": "sha512-HZ99Nd98KzYToNUD4+ysHp4+vMp1NmYTi59yqGpejHo/VffTgg0pereoib0nRRAHYUhGUGys5HGwR5yHYESWDA==",
       "requires": {
         "@ably/msgpack-js": "^0.4.0",
         "got": "^11.8.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "vitest": "^0.29.8"
   },
   "dependencies": {
-    "ably": "^1.2.42",
+    "ably": "^1.2.43",
     "nanoid": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "mock-socket": "^9.1.5",
     "prettier": "^2.8.3",
     "rollup": "^3.28.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
     "vitest": "^0.29.8"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:mjs": "npx tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",
     "build:cjs": "npx tsc --project tsconfig.cjs.json && cp res/package.cjs.json dist/cjs/package.json",
     "build:iife": "rm -rf dist/iife && npx tsc --project tsconfig.iife.json && rollup -c",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "examples:locks": "ts-node ./examples/locks.ts"
   },
   "exports": {
     "import": "./dist/mjs/index.js",

--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -347,6 +347,7 @@ describe('Cursors', () => {
         isConnected: true,
         profileData: {},
         location: {},
+        locks: new Map(),
         lastEvent: { name: 'enter', timestamp: 0 },
       };
 

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,0 +1,28 @@
+interface ErrorInfoValues {
+  message: string;
+  code: number;
+  statusCode: number;
+}
+
+// TODO: export ErrorInfo from ably-js and use that instead.
+export class ErrorInfo extends Error {
+  code: number;
+  statusCode: number;
+
+  constructor({ message, code, statusCode }: ErrorInfoValues) {
+    super(message);
+
+    if (typeof Object.setPrototypeOf !== 'undefined') {
+      Object.setPrototypeOf(this, ErrorInfo.prototype);
+    }
+
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export const ERR_LOCK_REQUEST_EXISTS = new ErrorInfo({
+  message: 'lock request already exists',
+  code: 40050,
+  statusCode: 400,
+});

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -26,3 +26,15 @@ export const ERR_LOCK_REQUEST_EXISTS = new ErrorInfo({
   code: 40050,
   statusCode: 400,
 });
+
+export const ERR_LOCK_IS_LOCKED = new ErrorInfo({
+  message: 'lock is currently locked',
+  code: 40051,
+  statusCode: 400,
+});
+
+export const ERR_LOCK_INVALIDATED = new ErrorInfo({
+  message: 'lock was invalidated by a concurrent lock request which now holds the lock',
+  code: 40052,
+  statusCode: 400,
+});

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -38,3 +38,9 @@ export const ERR_LOCK_INVALIDATED = new ErrorInfo({
   code: 40052,
   statusCode: 400,
 });
+
+export const ERR_LOCK_RELEASED = new ErrorInfo({
+  message: 'lock was released',
+  code: 40053,
+  statusCode: 400,
+});

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -2,8 +2,8 @@ import { it, describe, expect, vi, beforeEach } from 'vitest';
 import { Realtime, Types } from 'ably/promises';
 
 import Space from './Space.js';
-import type { SpaceMember } from './types.js';
-import { LockAttributes, LockStatus } from './Locks.js';
+import type { SpaceMember, LockStatus } from './types.js';
+import { LockAttributes } from './Locks.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 
 interface SpaceTestContext {

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -1,0 +1,90 @@
+import { it, describe, expect, vi, beforeEach } from 'vitest';
+import { Realtime, Types } from 'ably/promises';
+
+import Space from './Space.js';
+import { LockStatus } from './Locks.js';
+import { createPresenceMessage } from './utilities/test/fakes.js';
+
+interface SpaceTestContext {
+  client: Types.RealtimePromise;
+  space: Space;
+  presence: Types.RealtimePresencePromise;
+}
+
+vi.mock('ably/promises');
+
+describe('Locks (mockClient)', () => {
+  beforeEach<SpaceTestContext>((context) => {
+    const client = new Realtime({});
+    const presence = client.channels.get('').presence;
+
+    // support entering the space, which requires presence.get() to return a
+    // presenceMap including an entry for the client's connectionId.
+    vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
+      createPresenceMessage('enter', { connectionId: '1' }),
+    ]);
+
+    context.client = client;
+    context.space = new Space('test', client);
+    context.presence = presence;
+  });
+
+  describe('acquire', () => {
+    it<SpaceTestContext>('errors if acquiring before entering the space', ({ space }) => {
+      expect(space.locks.acquire('test')).rejects.toThrowError();
+    });
+
+    it<SpaceTestContext>('enters presence with a PENDING lock request for the current member', async ({
+      space,
+      presence,
+    }) => {
+      await space.enter();
+
+      const presenceUpdate = vi.spyOn(presence, 'update');
+
+      const lockID = 'test';
+      const req = await space.locks.acquire(lockID);
+      expect(req.status).toBe(LockStatus.PENDING);
+
+      const presenceMessage = expect.objectContaining({
+        extras: {
+          locks: [
+            expect.objectContaining({
+              id: lockID,
+              status: LockStatus.PENDING,
+            }),
+          ],
+        },
+      });
+      expect(presenceUpdate).toHaveBeenCalledWith(presenceMessage);
+    });
+
+    it<SpaceTestContext>('includes attributes in the lock request when provided', async ({ space, presence }) => {
+      await space.enter();
+
+      const presenceUpdate = vi.spyOn(presence, 'update');
+
+      const lockID = 'test';
+      const attributes = new Map();
+      attributes.set('key1', 'foo');
+      attributes.set('key2', 'bar');
+      const req = await space.locks.acquire(lockID, { attributes });
+      expect(req.attributes).toBe(attributes);
+
+      const presenceMessage = expect.objectContaining({
+        extras: {
+          locks: [expect.objectContaining({ attributes })],
+        },
+      });
+      expect(presenceUpdate).toHaveBeenCalledWith(presenceMessage);
+    });
+
+    it<SpaceTestContext>('errors if a PENDING request already exists', async ({ space }) => {
+      await space.enter();
+
+      const lockID = 'test';
+      await space.locks.acquire(lockID);
+      expect(space.locks.acquire(lockID)).rejects.toThrowError();
+    });
+  });
+});

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -19,9 +19,13 @@ describe('Locks (mockClient)', () => {
     const presence = client.channels.get('').presence;
 
     // support entering the space, which requires presence.get() to return a
-    // presenceMap including an entry for the client's connectionId.
+    // presenceMap including an entry for the client's connectionId, and also
+    // include some members with connectionIds which sort before and after for
+    // testing lock invalidation
     vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
       createPresenceMessage('enter', { connectionId: '1' }),
+      createPresenceMessage('enter', { connectionId: '0' }),
+      createPresenceMessage('enter', { connectionId: '2' }),
     ]);
 
     context.client = client;
@@ -85,6 +89,116 @@ describe('Locks (mockClient)', () => {
       const lockID = 'test';
       await space.locks.acquire(lockID);
       expect(space.locks.acquire(lockID)).rejects.toThrowError();
+    });
+  });
+
+  describe('processPresenceMessage', () => {
+    it<SpaceTestContext>('sets a PENDING request to LOCKED', async ({ space }) => {
+      await space.enter();
+      const member = space.members.getSelf()!;
+
+      const lockID = 'test';
+      const msg = Realtime.PresenceMessage.fromValues({
+        connectionId: member.connectionId,
+        extras: {
+          locks: [
+            {
+              id: lockID,
+              status: LockStatus.PENDING,
+              timestamp: Date.now(),
+            },
+          ],
+        },
+      });
+      space.locks.processPresenceMessage(msg);
+
+      const lock = member.locks.get(lockID)!;
+      expect(lock.status).toBe(LockStatus.LOCKED);
+    });
+
+    // use table driven tests to check whether a PENDING request for "self"
+    // (i.e. the current member) transitions to LOCKED or UNLOCKED when the
+    // referenced lock is already held by some other member with timestamp
+    // and/or connectionId before/after the current member's request.
+    const now = Date.now();
+    describe.each([
+      {
+        name: 'when the other member has the lock with an earlier timestamp',
+        desc: 'assigns the lock to the other member',
+        otherConnId: '0',
+        otherTimestamp: now - 100,
+        expectedSelfStatus: LockStatus.UNLOCKED,
+        expectedOtherStatus: LockStatus.LOCKED,
+      },
+      {
+        name: 'when the other member has the lock with the same timestamp but a lower connectionId',
+        desc: 'assigns the lock to the other member',
+        otherConnId: '0',
+        otherTimestamp: now,
+        expectedSelfStatus: LockStatus.UNLOCKED,
+        expectedOtherStatus: LockStatus.LOCKED,
+      },
+      {
+        name: 'when the other member has the lock with the same timestamp but a higher connectionId',
+        desc: 'assigns the lock to self',
+        otherConnId: '2',
+        otherTimestamp: now,
+        expectedSelfStatus: LockStatus.LOCKED,
+        expectedOtherStatus: LockStatus.UNLOCKED,
+      },
+      {
+        name: 'when the other member has the lock with a later timestamp',
+        desc: 'assigns the lock to self',
+        otherConnId: '0',
+        otherTimestamp: now + 100,
+        expectedSelfStatus: LockStatus.LOCKED,
+        expectedOtherStatus: LockStatus.UNLOCKED,
+      },
+    ])('$name', ({ desc, otherConnId, otherTimestamp, expectedSelfStatus, expectedOtherStatus }) => {
+      it<SpaceTestContext>(desc, async ({ client, space }) => {
+        await space.enter();
+
+        // process a PENDING request for the other member, which should
+        // transition to LOCKED
+        const lockID = 'test';
+        let msg = Realtime.PresenceMessage.fromValues({
+          connectionId: otherConnId,
+          extras: {
+            locks: [
+              {
+                id: lockID,
+                status: LockStatus.PENDING,
+                timestamp: otherTimestamp,
+              },
+            ],
+          },
+        });
+        space.locks.processPresenceMessage(msg);
+        const lock = space.locks.get(lockID)!;
+        expect(lock.member.connectionId).toBe(otherConnId);
+
+        // process a PENDING request for the current member and check the
+        // result matches what is expected
+        msg = Realtime.PresenceMessage.fromValues({
+          connectionId: client.connection.id,
+          extras: {
+            locks: [
+              {
+                id: lockID,
+                status: LockStatus.PENDING,
+                timestamp: now,
+              },
+            ],
+          },
+        });
+        space.locks.processPresenceMessage(msg);
+        const selfMember = space.members.getByConnectionId(client.connection.id!)!;
+        const selfLock = selfMember.locks.get(lockID)!;
+        expect(selfLock.status).toBe(expectedSelfStatus);
+        const otherMember = space.members.getByConnectionId(otherConnId)!;
+        const otherLock = otherMember.locks.get(lockID)!;
+        expect(otherLock.status).toBe(expectedOtherStatus);
+      });
     });
   });
 });

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -3,7 +3,7 @@ import { Realtime, Types } from 'ably/promises';
 
 import Space from './Space.js';
 import type { SpaceMember } from './types.js';
-import { LockStatus } from './Locks.js';
+import { LockAttributes, LockStatus } from './Locks.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 
 interface SpaceTestContext {
@@ -70,7 +70,7 @@ describe('Locks (mockClient)', () => {
       const presenceUpdate = vi.spyOn(presence, 'update');
 
       const lockID = 'test';
-      const attributes = new Map();
+      const attributes = new LockAttributes();
       attributes.set('key1', 'foo');
       attributes.set('key2', 'bar');
       const req = await space.locks.acquire(lockID, { attributes });

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -49,14 +49,14 @@ describe('Locks (mockClient)', () => {
 
       const lockID = 'test';
       const req = await space.locks.acquire(lockID);
-      expect(req.status).toBe(LockStatus.PENDING);
+      expect(req.status).toBe('pending');
 
       const presenceMessage = expect.objectContaining({
         extras: {
           locks: [
             expect.objectContaining({
               id: lockID,
-              status: LockStatus.PENDING,
+              status: 'pending',
             }),
           ],
         },
@@ -114,7 +114,7 @@ describe('Locks (mockClient)', () => {
           locks: [
             {
               id: lockID,
-              status: LockStatus.PENDING,
+              status: 'pending',
               timestamp: Date.now(),
             },
           ],
@@ -123,8 +123,8 @@ describe('Locks (mockClient)', () => {
       space.locks.processPresenceMessage(msg);
 
       const lock = member.locks.get(lockID)!;
-      expect(lock.status).toBe(LockStatus.LOCKED);
-      expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, LockStatus.LOCKED));
+      expect(lock.status).toBe('locked');
+      expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, 'locked'));
     });
 
     // use table driven tests to check whether a PENDING request for "self"
@@ -138,32 +138,32 @@ describe('Locks (mockClient)', () => {
         desc: 'assigns the lock to the other member',
         otherConnId: '0',
         otherTimestamp: now - 100,
-        expectedSelfStatus: LockStatus.UNLOCKED,
-        expectedOtherStatus: LockStatus.LOCKED,
+        expectedSelfStatus: 'unlocked',
+        expectedOtherStatus: 'locked',
       },
       {
         name: 'when the other member has the lock with the same timestamp but a lower connectionId',
         desc: 'assigns the lock to the other member',
         otherConnId: '0',
         otherTimestamp: now,
-        expectedSelfStatus: LockStatus.UNLOCKED,
-        expectedOtherStatus: LockStatus.LOCKED,
+        expectedSelfStatus: 'unlocked',
+        expectedOtherStatus: 'locked',
       },
       {
         name: 'when the other member has the lock with the same timestamp but a higher connectionId',
         desc: 'assigns the lock to self',
         otherConnId: '2',
         otherTimestamp: now,
-        expectedSelfStatus: LockStatus.LOCKED,
-        expectedOtherStatus: LockStatus.UNLOCKED,
+        expectedSelfStatus: 'locked',
+        expectedOtherStatus: 'unlocked',
       },
       {
         name: 'when the other member has the lock with a later timestamp',
         desc: 'assigns the lock to self',
         otherConnId: '0',
         otherTimestamp: now + 100,
-        expectedSelfStatus: LockStatus.LOCKED,
-        expectedOtherStatus: LockStatus.UNLOCKED,
+        expectedSelfStatus: 'locked',
+        expectedOtherStatus: 'unlocked',
       },
     ])('$name', ({ desc, otherConnId, otherTimestamp, expectedSelfStatus, expectedOtherStatus }) => {
       it<SpaceTestContext>(desc, async ({ client, space }) => {
@@ -177,7 +177,7 @@ describe('Locks (mockClient)', () => {
             locks: [
               {
                 id: lockID,
-                status: LockStatus.PENDING,
+                status: 'pending',
                 timestamp: otherTimestamp,
               },
             ],
@@ -196,7 +196,7 @@ describe('Locks (mockClient)', () => {
             locks: [
               {
                 id: lockID,
-                status: LockStatus.PENDING,
+                status: 'pending',
                 timestamp: now,
               },
             ],
@@ -210,13 +210,13 @@ describe('Locks (mockClient)', () => {
         const otherLock = otherMember.locks.get(lockID)!;
         expect(otherLock.status).toBe(expectedOtherStatus);
 
-        if (expectedSelfStatus === LockStatus.UNLOCKED) {
+        if (expectedSelfStatus === 'unlocked') {
           expect(emitSpy).toHaveBeenCalledTimes(1);
-          expect(emitSpy).toHaveBeenNthCalledWith(1, 'update', lockEvent(selfMember, LockStatus.UNLOCKED));
+          expect(emitSpy).toHaveBeenNthCalledWith(1, 'update', lockEvent(selfMember, 'unlocked'));
         } else {
           expect(emitSpy).toHaveBeenCalledTimes(2);
-          expect(emitSpy).toHaveBeenNthCalledWith(1, 'update', lockEvent(otherMember, LockStatus.UNLOCKED));
-          expect(emitSpy).toHaveBeenNthCalledWith(2, 'update', lockEvent(selfMember, LockStatus.LOCKED));
+          expect(emitSpy).toHaveBeenNthCalledWith(1, 'update', lockEvent(otherMember, 'unlocked'));
+          expect(emitSpy).toHaveBeenNthCalledWith(2, 'update', lockEvent(selfMember, 'locked'));
         }
       });
     });
@@ -231,7 +231,7 @@ describe('Locks (mockClient)', () => {
           locks: [
             {
               id: lockID,
-              status: LockStatus.PENDING,
+              status: 'pending',
               timestamp: Date.now(),
             },
           ],
@@ -249,7 +249,7 @@ describe('Locks (mockClient)', () => {
 
       const lock = member.locks.get(lockID);
       expect(lock).not.toBeDefined();
-      expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, LockStatus.UNLOCKED));
+      expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, 'unlocked'));
     });
   });
 
@@ -269,7 +269,7 @@ describe('Locks (mockClient)', () => {
           locks: [
             {
               id: lockID,
-              status: LockStatus.PENDING,
+              status: 'pending',
               timestamp: Date.now(),
             },
           ],

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -1,0 +1,74 @@
+import { Types } from 'ably';
+
+import Space from './Space.js';
+import type { PresenceMember } from './utilities/types.js';
+import { ERR_LOCK_REQUEST_EXISTS } from './Errors.js';
+
+export enum LockStatus {
+  PENDING = 'pending',
+  LOCKED = 'locked',
+  UNLOCKED = 'unlocked',
+}
+
+export type LockRequest = {
+  id: string;
+  status: LockStatus;
+  timestamp: number;
+  attributes?: Map<string, string>;
+  reason?: Types.ErrorInfo;
+};
+
+interface LockOptions {
+  attributes: Map<string, string>;
+}
+
+export default class Locks {
+  constructor(
+    private space: Space,
+    private presenceUpdate: (update: PresenceMember['data'], extras?: any) => Promise<void>,
+  ) {}
+
+  async acquire(id: string, opts?: LockOptions): Promise<LockRequest> {
+    const self = this.space.members.getSelf();
+    if (!self) {
+      throw new Error('Must enter a space before acquiring a lock');
+    }
+
+    // check there isn't an existing PENDING or LOCKED request for the current
+    // member, since we do not support nested locks
+    let req = self.locks.get(id);
+    if (req && req.status !== LockStatus.UNLOCKED) {
+      throw ERR_LOCK_REQUEST_EXISTS;
+    }
+
+    // initialise a new PENDING request
+    req = {
+      id,
+      status: LockStatus.PENDING,
+      timestamp: Date.now(),
+    };
+    if (opts) {
+      req.attributes = opts.attributes;
+    }
+    self.locks.set(id, req);
+
+    // reflect the change in the member's presence data
+    const update: PresenceMember['data'] = {
+      profileUpdate: {
+        id: null,
+        current: self.profileData,
+      },
+      locationUpdate: {
+        id: null,
+        current: self?.location ?? null,
+        previous: null,
+      },
+    };
+    const extras = {
+      locks: Array.from(self.locks.values()),
+    };
+    await this.presenceUpdate(update, extras);
+
+    return req;
+  }
+}

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -1,7 +1,7 @@
 import { Types } from 'ably';
 
 import Space from './Space.js';
-import type { SpaceMember } from './types.js';
+import type { Lock, LockRequest, SpaceMember } from './types.js';
 import type { PresenceMember } from './utilities/types.js';
 import { ERR_LOCK_IS_LOCKED, ERR_LOCK_INVALIDATED, ERR_LOCK_REQUEST_EXISTS, ERR_LOCK_RELEASED } from './Errors.js';
 import EventEmitter, {
@@ -10,21 +10,6 @@ import EventEmitter, {
   type EventKey,
   type EventListener,
 } from './utilities/EventEmitter.js';
-
-export type LockStatus = 'pending' | 'locked' | 'unlocked';
-
-export type Lock = {
-  member: SpaceMember;
-  request: LockRequest;
-};
-
-export type LockRequest = {
-  id: string;
-  status: LockStatus;
-  timestamp: number;
-  attributes?: LockAttributes;
-  reason?: Types.ErrorInfo;
-};
 
 export class LockAttributes extends Map<string, string> {
   toJSON() {

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -22,12 +22,18 @@ export type LockRequest = {
   id: string;
   status: LockStatus;
   timestamp: number;
-  attributes?: Map<string, string>;
+  attributes?: LockAttributes;
   reason?: Types.ErrorInfo;
 };
 
+export class LockAttributes extends Map<string, string> {
+  toJSON() {
+    return Object.fromEntries(this);
+  }
+}
+
 interface LockOptions {
-  attributes: Map<string, string>;
+  attributes: LockAttributes;
 }
 
 type LockEventMap = {

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -138,7 +138,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
       return;
     }
 
-    if (!message.extras || !message.extras.locks || !Array.isArray(message.extras.locks)) {
+    if (!Array.isArray(message?.extras?.locks)) {
       // there are no locks in presence, so release any existing locks for the
       // member
       for (const [id, lock] of member.locks.entries()) {

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -123,6 +123,7 @@ class Members extends EventEmitter<MemberEventsMap> {
       isConnected: message.action !== 'leave',
       profileData: message.data.profileUpdate.current,
       location: message.data.locationUpdate.current,
+      locks: new Map(),
       lastEvent: {
         name: message.action,
         timestamp: message.timestamp,

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -4,7 +4,6 @@ import { Realtime, Types } from 'ably/promises';
 import Space from './Space.js';
 import Locations from './Locations.js';
 import Cursors from './Cursors.js';
-import { LockStatus } from './Locks.js';
 
 import {
   createPresenceEvent,
@@ -81,8 +80,8 @@ describe('Space', () => {
           connectionId: '1',
           extras: {
             locks: [
-              { id: 'lock1', status: LockStatus.LOCKED },
-              { id: 'lock2', status: LockStatus.PENDING },
+              { id: 'lock1', status: 'locked' },
+              { id: 'lock2', status: 'pending' },
             ],
           },
         }),
@@ -90,8 +89,8 @@ describe('Space', () => {
           connectionId: '2',
           extras: {
             locks: [
-              { id: 'lock1', status: LockStatus.UNLOCKED },
-              { id: 'lock3', status: LockStatus.LOCKED },
+              { id: 'lock1', status: 'unlocked' },
+              { id: 'lock3', status: 'locked' },
             ],
           },
         }),
@@ -100,13 +99,13 @@ describe('Space', () => {
 
       const member1 = space.members.getByConnectionId('1')!;
       expect(member1.locks.size).toEqual(2);
-      expect(member1.locks.get('lock1')!.status).toBe(LockStatus.LOCKED);
-      expect(member1.locks.get('lock2')!.status).toBe(LockStatus.LOCKED);
+      expect(member1.locks.get('lock1')!.status).toBe('locked');
+      expect(member1.locks.get('lock2')!.status).toBe('locked');
 
       const member2 = space.members.getByConnectionId('2')!;
       expect(member2.locks.size).toEqual(2);
-      expect(member2.locks.get('lock1')!.status).toBe(LockStatus.UNLOCKED);
-      expect(member2.locks.get('lock3')!.status).toBe(LockStatus.LOCKED);
+      expect(member2.locks.get('lock1')!.status).toBe('unlocked');
+      expect(member2.locks.get('lock3')!.status).toBe('locked');
     });
   });
 

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -97,6 +97,7 @@ class Space extends EventEmitter<SpaceEventsMap> {
   private onPresenceUpdate(message: PresenceMember) {
     this.members.processPresenceMessage(message);
     this.locations.processPresenceMessage(message);
+    this.locks.processPresenceMessage(message);
     this.emit('update', { members: this.members.getAll() });
   }
 

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -58,21 +58,21 @@ class Space extends EventEmitter<SpaceEventsMap> {
     this.locks = new Locks(this, this.presenceUpdate);
   }
 
-  private presenceUpdate = (data: PresenceMember['data'], extras?: any) => {
+  private presenceUpdate = (data: PresenceMember['data'], extras?: PresenceMember['extras']) => {
     if (!extras) {
       return this.channel.presence.update(data);
     }
     return this.channel.presence.update(Ably.Realtime.PresenceMessage.fromValues({ data, extras }));
   };
 
-  private presenceEnter = (data: PresenceMember['data'], extras?: any) => {
+  private presenceEnter = (data: PresenceMember['data'], extras?: PresenceMember['extras']) => {
     if (!extras) {
       return this.channel.presence.enter(data);
     }
     return this.channel.presence.enter(Ably.Realtime.PresenceMessage.fromValues({ data, extras }));
   };
 
-  private presenceLeave = (data: PresenceMember['data'], extras?: any) => {
+  private presenceLeave = (data: PresenceMember['data'], extras?: PresenceMember['extras']) => {
     if (!extras) {
       return this.channel.presence.leave(data);
     }

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -113,6 +113,8 @@ class Space extends EventEmitter<SpaceEventsMap> {
         const presenceMessages = await presence.get();
         const members = this.members.mapPresenceMembersToSpaceMembers(presenceMessages);
 
+        presenceMessages.forEach((msg) => this.locks.processPresenceMessage(msg));
+
         resolve(members);
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,9 @@ export type {
   SpaceOptions,
   ProfileData,
   SpaceMember,
+  Lock,
+  LockRequest,
+  LockStatus,
 } from './types.js';
+
+export { LockAttributes } from './Locks.js';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import { Types } from 'ably';
+import { LockRequest } from './Locks.js';
 
 export interface CursorsOptions {
   outboundBatchInterval: number;
@@ -32,6 +33,7 @@ export interface SpaceMember {
   isConnected: boolean;
   profileData: ProfileData;
   location: unknown;
+  locks: Map<string, LockRequest>;
   lastEvent: {
     name: Types.PresenceAction;
     timestamp: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,4 @@
 import { Types } from 'ably';
-import { LockRequest } from './Locks.js';
 
 export interface CursorsOptions {
   outboundBatchInterval: number;
@@ -39,3 +38,18 @@ export interface SpaceMember {
     timestamp: number;
   };
 }
+
+export type LockStatus = 'pending' | 'locked' | 'unlocked';
+
+export type Lock = {
+  member: SpaceMember;
+  request: LockRequest;
+};
+
+export type LockRequest = {
+  id: string;
+  status: LockStatus;
+  timestamp: number;
+  attributes?: LockAttributes;
+  reason?: Types.ErrorInfo;
+};

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -21,6 +21,7 @@ const enterPresenceMessage: Types.PresenceMessage = {
       previous: null,
     },
   },
+  extras: {},
   action: 'enter',
   connectionId: '1',
   id: '1',

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -100,6 +100,7 @@ const createSpaceMember = (override?: Partial<SpaceMember>): SpaceMember => {
     profileData: null,
     location: null,
     lastEvent: { name: 'update', timestamp: 1 },
+    locks: new Map(),
     ...override,
   };
 };

--- a/src/utilities/types.d.ts
+++ b/src/utilities/types.d.ts
@@ -2,6 +2,7 @@ import { Types } from 'ably';
 
 import { EventKey, EventListener, EventMap } from './EventEmitter.js';
 import { ProfileData } from '../types.js';
+import { LockRequest } from '../Locks.js';
 
 export type PresenceMember = {
   data: {
@@ -14,6 +15,9 @@ export type PresenceMember = {
       previous: unknown;
       current: unknown;
     };
+  };
+  extras?: {
+    locks: LockRequest[];
   };
 } & Omit<Types.PresenceMessage, 'data'>;
 

--- a/src/utilities/types.d.ts
+++ b/src/utilities/types.d.ts
@@ -1,8 +1,7 @@
 import { Types } from 'ably';
 
 import { EventKey, EventListener, EventMap } from './EventEmitter.js';
-import { ProfileData } from '../types.js';
-import { LockRequest } from '../Locks.js';
+import { ProfileData, LockRequest } from '../types.js';
 
 export type PresenceMember = {
   data: {


### PR DESCRIPTION
This is a draft PR to get feedback on an early implementation of Component Locking.

This is not a complete implementation, but opening for early feedback and to align with changes proposed in https://github.com/ably-labs/spaces/pull/101.

**[UPDATE: 2023-08-07]**

I have now implemented all four proposed locking features: Query, Acquire, Release, and Subscribe.

## Query

`space.locks.get` is used to query whether a lock identifier is currently locked and by whom. It returns a `Lock` type which has the following fields:

```typescript
type Lock = {
  member: SpaceMember;
  request: LockRequest;
};
```

For example:

```javascript
// check if the id is locked
const isLocked = space.locks.get(id) !== undefined;

// check which member has the lock
const { member } = space.locks.get(id);

// check the lock attributes assigned by the member holding the lock
const { request } = space.locks.get(id);
const value = request.attributes.get(key);
```

## Acquire

`space.locks.acquire` initialises a lock request, adds it to the `locks` field of presence message extras, and calls `presence.update`.

It returns a Promise which resolves once `presence.update` resolves.

```javascript
const req = await space.locks.acquire(id);

// or with some attributes
const attributes = new Map();
attributes.set('key', 'value');
const req = await space.locks.acquire(id, { attributes });
```

It throws an error if a lock request already exists for the given identifier with a status of `PENDING` or `LOCKED`.

## Release

`space.locks.release` releases a previously requested lock by removing it from the `locks` field of presence message extras, and calls `presence.update`.

It returns a Promise which resolves once `presence.update` resolves.

```javascript
await space.locks.release(id);
```

## Subscribe

`space.locks.subscribe` subscribes to changes in lock status across all members.

The callback is called with a value of type `Lock`.

```javascript
space.locks.subscribe('update', (lock) => {
  // lock.member is the requesting member
  // lock.request is the request made by the member
});

// or with destructuring:
space.locks.subscribe('update', ({ member, request }) => {
  // request.status is the status of the request, one of PENDING, LOCKED, or UNLOCKED
  // request.reason is an ErrorInfo if the status is UNLOCKED
});
```

Such changes occur when:

- a `PENDING` request transitions to `LOCKED` (i.e. the requesting member now holds the lock)
- a `PENDING` request transitions to `UNLOCKED` (i.e. the requesting member does not hold the lock since another member already does)
- a `LOCKED` request transitions to `UNLOCKED` (i.e. the lock was either released or invalidated by a concurrent request which took precedence)
- an `UNLOCKED` request transitions to `LOCKED` (i.e. the requesting member reacquired a lock)

---

I've also added an example in `examples/locks.ts` which can be run with `npm run examples:locks`:

```
$ npm run examples:locks

> @ably-labs/spaces@0.0.12 examples:locks
> ts-node ./examples/locks.ts

2023-08-07T20:26:16.220Z INFO initialising Ably client
2023-08-07T20:26:16.222Z INFO entering the "example" space
2023-08-07T20:26:16.670Z INFO setting location to {"slideId":"123","elementId":"456"}
2023-08-07T20:26:16.976Z INFO checking if location is locked
2023-08-07T20:26:16.978Z INFO location is not locked
2023-08-07T20:26:16.978Z INFO subscribing to lock events
2023-08-07T20:26:16.978Z INFO attempting to lock "/slides/123/element/456"
2023-08-07T20:26:17.012Z INFO waiting for lock event
2023-08-07T20:26:17.017Z INFO received lock update for "/slides/123/element/456", status=locked
2023-08-07T20:26:17.018Z INFO unsubscribing from lock events
2023-08-07T20:26:17.018Z INFO lock status is "locked"
2023-08-07T20:26:17.018Z INFO releasing the lock
2023-08-07T20:26:17.514Z INFO done
```

---

[MMB-213] [MMB-214] [MMB-215]

[MMB-213]: https://ably.atlassian.net/browse/MMB-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ