### PR TITLE
Fixed an issue in README where a code block wasn't being closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ space.enter({
 
 // Publish locationUpdate event with a client's location when they select a UI element
 space.locations.set({ slide: '3', component: 'slide-title' });
+```
 
 The following is an example `locationUpdate` event received by subscribers when a user changes location:
 


### PR DESCRIPTION
Fixed an issue where in the README [Locations](https://github.com/ably-labs/spaces/blob/main/README.md) section, the code block isn't being closed, which causes the non-code content to be included within a code block.

![A screenshot of the code sample with the README. This screenshot shows a code block that hasn't been closed, forcing the non-code text to be included in that code block.](https://github.com/ably-labs/spaces/assets/2411269/ad5860a9-529f-459f-a8f5-7fadc0ec7c42)