### PR TITLE
locks: Move lock state out of SpaceMember

### DIFF
--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -339,7 +339,6 @@ describe('Cursors', () => {
         isConnected: true,
         profileData: {},
         location: {},
-        locks: new Map(),
         lastEvent: { name: 'enter', timestamp: 0 },
       };
 

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -122,7 +122,7 @@ describe('Locks (mockClient)', () => {
       });
       space.locks.processPresenceMessage(msg);
 
-      const lock = member.locks.get(lockID)!;
+      const lock = space.locks.getLockRequest(lockID, member.connectionId)!;
       expect(lock.status).toBe('locked');
       expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, 'locked'));
     });
@@ -204,10 +204,10 @@ describe('Locks (mockClient)', () => {
         });
         space.locks.processPresenceMessage(msg);
         const selfMember = space.members.getByConnectionId(client.connection.id!)!;
-        const selfLock = selfMember.locks.get(lockID)!;
+        const selfLock = space.locks.getLockRequest(lockID, selfMember.connectionId)!;
         expect(selfLock.status).toBe(expectedSelfStatus);
         const otherMember = space.members.getByConnectionId(otherConnId)!;
-        const otherLock = otherMember.locks.get(lockID)!;
+        const otherLock = space.locks.getLockRequest(lockID, otherMember.connectionId)!;
         expect(otherLock.status).toBe(expectedOtherStatus);
 
         if (expectedSelfStatus === 'unlocked') {
@@ -247,7 +247,7 @@ describe('Locks (mockClient)', () => {
       });
       space.locks.processPresenceMessage(msg);
 
-      const lock = member.locks.get(lockID);
+      const lock = space.locks.getLockRequest(lockID, member.connectionId);
       expect(lock).not.toBeDefined();
       expect(emitSpy).toHaveBeenCalledWith('update', lockEvent(member, 'unlocked'));
     });

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -44,9 +44,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
   get(id: string): Lock | undefined {
     const locks = this.locks.get(id);
-    if (!locks) {
-      return;
-    }
+    if (!locks) return;
     for (const lock of locks.values()) {
       if (lock.request.status === 'locked') {
         return lock;
@@ -131,9 +129,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
   processPresenceMessage(message: Types.PresenceMessage) {
     const member = this.space.members.getByConnectionId(message.connectionId);
-    if (!member) {
-      return;
-    }
+    if (!member) return;
 
     if (!Array.isArray(message?.extras?.locks)) {
       // there are no locks in presence, so release any existing locks for the
@@ -253,9 +249,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
   getLock(id: string, connectionId: string): Lock | undefined {
     const locks = this.locks.get(id);
-    if (!locks) {
-      return;
-    }
+    if (!locks) return;
     return locks.get(connectionId);
   }
 
@@ -270,17 +264,13 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
   deleteLock(id: string, connectionId: string) {
     const locks = this.locks.get(id);
-    if (!locks) {
-      return;
-    }
+    if (!locks) return;
     return locks.delete(connectionId);
   }
 
   getLockRequest(id: string, connectionId: string): LockRequest | undefined {
     const lock = this.getLock(id, connectionId);
-    if (!lock) {
-      return;
-    }
+    if (!lock) return;
     return lock.request;
   }
 

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -123,7 +123,6 @@ class Members extends EventEmitter<MemberEventsMap> {
       isConnected: message.action !== 'leave',
       profileData: message.data.profileUpdate.current,
       location: message.data.locationUpdate.current,
-      locks: new Map(),
       lastEvent: {
         name: message.action,
         timestamp: message.timestamp,

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -80,8 +80,8 @@ describe('Space', () => {
           connectionId: '1',
           extras: {
             locks: [
-              { id: 'lock1', status: 'locked' },
-              { id: 'lock2', status: 'pending' },
+              { id: 'lock1', status: 'pending', timestamp: 2 },
+              { id: 'lock2', status: 'pending', timestamp: 2 },
             ],
           },
         }),
@@ -89,8 +89,8 @@ describe('Space', () => {
           connectionId: '2',
           extras: {
             locks: [
-              { id: 'lock1', status: 'unlocked' },
-              { id: 'lock3', status: 'locked' },
+              { id: 'lock1', status: 'pending', timestamp: 1 },
+              { id: 'lock3', status: 'pending', timestamp: 3 },
             ],
           },
         }),
@@ -98,14 +98,14 @@ describe('Space', () => {
       await space.enter();
 
       const member1 = space.members.getByConnectionId('1')!;
-      expect(member1.locks.size).toEqual(2);
-      expect(member1.locks.get('lock1')!.status).toBe('locked');
-      expect(member1.locks.get('lock2')!.status).toBe('locked');
-
       const member2 = space.members.getByConnectionId('2')!;
-      expect(member2.locks.size).toEqual(2);
-      expect(member2.locks.get('lock1')!.status).toBe('unlocked');
-      expect(member2.locks.get('lock3')!.status).toBe('locked');
+
+      const lock1 = space.locks.get('lock1')!;
+      expect(lock1.member).toEqual(member2);
+      const lock2 = space.locks.get('lock2')!;
+      expect(lock2.member).toEqual(member1);
+      const lock3 = space.locks.get('lock3')!;
+      expect(lock3.member).toEqual(member2);
     });
   });
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,7 +32,6 @@ export interface SpaceMember {
   isConnected: boolean;
   profileData: ProfileData;
   location: unknown;
-  locks: Map<string, LockRequest>;
   lastEvent: {
     name: Types.PresenceAction;
     timestamp: number;

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -100,7 +100,6 @@ const createSpaceMember = (override?: Partial<SpaceMember>): SpaceMember => {
     profileData: null,
     location: null,
     lastEvent: { name: 'update', timestamp: 1 },
-    locks: new Map(),
     ...override,
   };
 };


### PR DESCRIPTION
In preparation for `SpaceMember` being retrieved directly from the presenceMap rather than maintained separately (see https://ably.atlassian.net/browse/MMB-182).

[MMB-182]

[MMB-182]: https://ably.atlassian.net/browse/MMB-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ