### PR TITLE
space: Don't maintain leavers within the members array

### DIFF
--- a/src/Leavers.ts
+++ b/src/Leavers.ts
@@ -1,6 +1,7 @@
 import type { SpaceMember } from './types.js';
 
-type SpaceLeaver = SpaceMember & {
+type SpaceLeaver = {
+  member: SpaceMember;
   timeoutId: ReturnType<typeof setTimeout>;
 };
 
@@ -10,7 +11,11 @@ class Leavers {
   constructor(private offlineTimeout: number) {}
 
   getByConnectionId(connectionId: string): SpaceLeaver | undefined {
-    return this.leavers.find((leaver) => leaver.connectionId === connectionId);
+    return this.leavers.find((leaver) => leaver.member.connectionId === connectionId);
+  }
+
+  getAll(): SpaceLeaver[] {
+    return this.leavers;
   }
 
   addLeaver(member: SpaceMember, timeoutCallback: () => void) {
@@ -18,13 +23,13 @@ class Leavers {
     this.removeLeaver(member.connectionId);
 
     this.leavers.push({
-      ...member,
+      member,
       timeoutId: setTimeout(timeoutCallback, this.offlineTimeout),
     });
   }
 
   removeLeaver(connectionId: string) {
-    const leaverIndex = this.leavers.findIndex((leaver) => leaver.connectionId === connectionId);
+    const leaverIndex = this.leavers.findIndex((leaver) => leaver.member.connectionId === connectionId);
 
     if (leaverIndex >= 0) {
       clearTimeout(this.leavers[leaverIndex].timeoutId);

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -52,7 +52,7 @@ class Members extends EventEmitter<MemberEventsMap> {
     // Emit profileData updates only if they are different then the last held update.
     // A locationUpdate is handled in Locations.
     if (message.data.profileUpdate.id && this.lastMemberUpdate[connectionId] !== message.data.profileUpdate.id) {
-      this.lastMemberUpdate[message.connectionId] = message.data.locationUpdate.id;
+      this.lastMemberUpdate[message.connectionId] = message.data.profileUpdate.id;
       this.emit('update', memberUpdate);
     }
   }

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -25,7 +25,7 @@ class Members extends EventEmitter<MemberEventsMap> {
 
   constructor(private space: Space) {
     super();
-    this.leavers = new Leavers(this.space);
+    this.leavers = new Leavers(this.space.options.offlineTimeout);
   }
 
   processPresenceMessage(message: PresenceMember) {
@@ -34,11 +34,8 @@ class Members extends EventEmitter<MemberEventsMap> {
     const isMember = !!this.getByConnectionId(connectionId);
     const memberUpdate = this.createMember(message);
 
-    if (action === 'leave' && !isLeaver) {
-      this.leavers.addLeaver(connectionId);
-      this.emit('leave', memberUpdate);
-    } else if (action === 'leave' && isLeaver) {
-      this.leavers.refreshTimeout(connectionId);
+    if (action === 'leave') {
+      this.leavers.addLeaver(memberUpdate, () => this.removeMember(connectionId));
       this.emit('leave', memberUpdate);
     } else if (isLeaver) {
       this.leavers.removeLeaver(connectionId);

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -189,7 +189,7 @@ describe('Space', () => {
         data: createProfileUpdate({ current: { name: 'Betty' } }),
       });
 
-      expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+      expect(callbackSpy).toHaveBeenNthCalledWith(2, {
         members: [
           member1,
           createSpaceMember({
@@ -215,7 +215,7 @@ describe('Space', () => {
         data: createProfileUpdate({ current: { name: 'Betty' } }),
       });
 
-      expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+      expect(callbackSpy).toHaveBeenNthCalledWith(2, {
         members: [createSpaceMember({ profileData: { name: 'Betty' } })],
       });
     });
@@ -230,7 +230,7 @@ describe('Space', () => {
       });
 
       createPresenceEvent(space, 'leave');
-      expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+      expect(callbackSpy).toHaveBeenNthCalledWith(2, {
         members: [createSpaceMember({ isConnected: false, lastEvent: { name: 'leave', timestamp: 1 } })],
       });
     });
@@ -254,13 +254,13 @@ describe('Space', () => {
         });
 
         createPresenceEvent(space, 'leave');
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+        expect(callbackSpy).toHaveBeenNthCalledWith(2, {
           members: [createSpaceMember({ isConnected: false, lastEvent: { name: 'leave', timestamp: 1 } })],
         });
 
         vi.advanceTimersByTime(130_000);
 
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, { members: [] });
+        expect(callbackSpy).toHaveBeenNthCalledWith(3, { members: [] });
         expect(callbackSpy).toHaveBeenCalledTimes(3);
       });
 
@@ -270,7 +270,7 @@ describe('Space', () => {
 
         createPresenceEvent(space, 'enter');
         createPresenceEvent(space, 'enter', { clientId: '2', connectionId: '2' });
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+        expect(callbackSpy).toHaveBeenNthCalledWith(2, {
           members: [
             createSpaceMember({ lastEvent: { name: 'enter', timestamp: 1 } }),
             createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
@@ -278,7 +278,7 @@ describe('Space', () => {
         });
 
         createPresenceEvent(space, 'leave');
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+        expect(callbackSpy).toHaveBeenNthCalledWith(3, {
           members: [
             createSpaceMember({ lastEvent: { name: 'leave', timestamp: 1 }, isConnected: false }),
             createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
@@ -287,7 +287,7 @@ describe('Space', () => {
 
         vi.advanceTimersByTime(60_000);
         createPresenceEvent(space, 'enter');
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, {
+        expect(callbackSpy).toHaveBeenNthCalledWith(4, {
           members: [
             createSpaceMember({ lastEvent: { name: 'enter', timestamp: 1 } }),
             createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
@@ -295,13 +295,6 @@ describe('Space', () => {
         });
 
         vi.advanceTimersByTime(130_000); // 2:10 passed, default timeout is 2 min
-        expect(callbackSpy).toHaveBeenNthCalledWith(1, {
-          members: [
-            createSpaceMember({ lastEvent: { name: 'enter', timestamp: 1 } }),
-            createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
-          ],
-        });
-
         expect(callbackSpy).toHaveBeenCalledTimes(4);
       });
 

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -280,8 +280,8 @@ describe('Space', () => {
         createPresenceEvent(space, 'leave');
         expect(callbackSpy).toHaveBeenNthCalledWith(3, {
           members: [
-            createSpaceMember({ lastEvent: { name: 'leave', timestamp: 1 }, isConnected: false }),
             createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
+            createSpaceMember({ lastEvent: { name: 'leave', timestamp: 1 }, isConnected: false }),
           ],
         });
 
@@ -289,8 +289,8 @@ describe('Space', () => {
         createPresenceEvent(space, 'enter');
         expect(callbackSpy).toHaveBeenNthCalledWith(4, {
           members: [
-            createSpaceMember({ lastEvent: { name: 'enter', timestamp: 1 } }),
             createSpaceMember({ clientId: '2', connectionId: '2', lastEvent: { name: 'enter', timestamp: 1 } }),
+            createSpaceMember({ lastEvent: { name: 'enter', timestamp: 1 } }),
           ],
         });
 


### PR DESCRIPTION
The `Leavers` class is used to track members which have recently gone offline (i.e. they left presence within the last [120s](https://github.com/ably-labs/spaces/blob/main/src/Space.ts#L23)), and they are currently also maintained within the `members` array within the `Members` class until they are finally removed.

We plan to remove the `members` array in favour of loading members directly from the presenceMap (see https://ably.atlassian.net/browse/MMB-182), which means it will no longer contain leavers, and so in preparation for that change, this PR decouples the leavers from the `members` array and instead concats them in `members.getAll()`.

[MMB-182]

[MMB-182]: https://ably.atlassian.net/browse/MMB-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ