### PR TITLE
Make get and set functions async

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => {
     const enter = async () => {
       const name = getRandomName();
       await space.enter({ name, color: getRandomColor() });
-      space.locations.set({ slide: `${0}`, element: null });
+      await space.locations.set({ slide: `${0}`, element: null });
     };
 
     enter();

--- a/demo/src/hooks/useMembers.ts
+++ b/demo/src/hooks/useMembers.ts
@@ -24,32 +24,36 @@ export const useMembers: () => Partial<{ self?: Member; others: Member[]; member
   useEffect(() => {
     if (!space) return;
 
-    const initSelf = space.members.getSelf();
-    const initMembers = space.members.getAll();
+    const init = async () => {
+      const initSelf = await space.members.getSelf();
+      const initMembers = await space.members.getAll();
 
-    if (isMember(initSelf)) {
-      setSelf(initSelf);
-    }
-
-    if (areMembers(initMembers)) {
-      setMembers(initMembers);
-      setOthers(membersToOthers(initMembers, initSelf));
-    }
-
-    const handler = ({ members }: { members: SpaceMember[] }) => {
-      const self = space.members.getSelf();
-
-      if (isMember(self)) {
-        setSelf(self);
+      if (isMember(initSelf)) {
+        setSelf(initSelf);
       }
 
-      if (areMembers(members)) {
-        setMembers([...members]);
-        setOthers(membersToOthers([...members], self));
+      if (areMembers(initMembers)) {
+        setMembers(initMembers);
+        setOthers(membersToOthers(initMembers, initSelf));
       }
+
+      const handler = async ({ members }: { members: SpaceMember[] }) => {
+        const self = await space.members.getSelf();
+
+        if (isMember(self)) {
+          setSelf(self);
+        }
+
+        if (areMembers(members)) {
+          setMembers([...members]);
+          setOthers(membersToOthers([...members], self));
+        }
+      };
+
+      space.subscribe('update', handler);
     };
 
-    space.subscribe('update', handler);
+    init();
 
     return () => {
       space.unsubscribe('update', handler);

--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -282,19 +282,19 @@ type set = (update: Location) => void;
 ### getSelf
 Get location for self
 ```ts
-space.locations.getSelf()
+await space.locations.getSelf()
 ```
 ### getAll
 Get location for all members
 
 ```ts
-space.locations.getAll()
+await space.locations.getAll()
 ```
 ### getOthers
 Get location for other members
 
 ```ts
-space.locations.getOthers()
+await space.locations.getOthers()
 ```
 
 

--- a/examples/live-cursors.ts
+++ b/examples/live-cursors.ts
@@ -16,8 +16,9 @@ const space = await spaces.get('slide-deck-224');
 space.enter({ name: 'Helmut' });
 
 // Listen to all changes to all members within a space
-space.cursors.subscribe('update', (cursorUpdate) => {
-  const member = space.members.getAll().find((member) => member.connectionId === cursorUpdate.connectionId);
+space.cursors.subscribe('update', async (cursorUpdate) => {
+  const members = await space.members.getAll();
+  const member = members.find((member) => member.connectionId === cursorUpdate.connectionId);
   renderCursor(cursorUpdate, member);
 });
 

--- a/examples/location.ts
+++ b/examples/location.ts
@@ -22,4 +22,4 @@ space.locations.subscribe('update', ({ member, currentLocation, previousLocation
 });
 
 // Set your location
-space.locations.set({ slide: 0, elementId: 'title' });
+await space.locations.set({ slide: 0, elementId: 'title' });

--- a/examples/locking.ts
+++ b/examples/locking.ts
@@ -22,8 +22,8 @@ if (!isLocked) {
 }
 
 // Update UI when parts of the UI are locked
-space.locks.subscribe('update', (lock) => {
-  const self = space.members.getSelf();
+space.locks.subscribe('update', async (lock) => {
+  const self = await space.members.getSelf();
 
   if (lock.request.status === LockStatus.LOCKED && self.connectionId === lock.member.connectionId) {
     const location = {

--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -464,7 +464,7 @@ describe('Cursors', () => {
       selfStub,
     }) => {
       vi.spyOn(space.cursors, 'getAll').mockImplementation(async () => lastCursorPositionsStub);
-      vi.spyOn(space.members, 'getSelf').mockReturnValue(selfStub);
+      vi.spyOn(space.members, 'getSelf').mockResolvedValue(selfStub);
 
       const selfCursor = await space.cursors.getSelf();
       expect(selfCursor).toEqual(lastCursorPositionsStub['connectionId1']);
@@ -472,7 +472,7 @@ describe('Cursors', () => {
 
     it<CursorsTestContext>('returns an empty object if self is not present in cursors', async ({ space }) => {
       vi.spyOn(space.cursors, 'getAll').mockResolvedValue({});
-      vi.spyOn(space.members, 'getSelf').mockReturnValue(undefined);
+      vi.spyOn(space.members, 'getSelf').mockResolvedValue(undefined);
 
       const others = await space.cursors.getOthers();
       expect(others).toEqual({});
@@ -495,7 +495,7 @@ describe('Cursors', () => {
       };
 
       vi.spyOn(space.cursors, 'getAll').mockResolvedValue(onlyMyCursor);
-      vi.spyOn(space.members, 'getSelf').mockReturnValue(selfStub);
+      vi.spyOn(space.members, 'getSelf').mockResolvedValue(selfStub);
 
       const others = await space.cursors.getOthers();
       expect(others).toEqual({});
@@ -507,7 +507,7 @@ describe('Cursors', () => {
       lastCursorPositionsStub,
     }) => {
       vi.spyOn(space.cursors, 'getAll').mockResolvedValue(lastCursorPositionsStub);
-      vi.spyOn(space.members, 'getSelf').mockReturnValue(selfStub);
+      vi.spyOn(space.members, 'getSelf').mockResolvedValue(selfStub);
 
       const others = await space.cursors.getOthers();
       expect(others).toEqual({

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -44,8 +44,8 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
    * @param {CursorUpdate} cursor
    * @return {void}
    */
-  set(cursor: Pick<CursorUpdate, 'position' | 'data'>): void {
-    const self = this.space.members.getSelf();
+  async set(cursor: Pick<CursorUpdate, 'position' | 'data'>) {
+    const self = await this.space.members.getSelf();
 
     if (!self) {
       throw new Error('Must enter a space before setting a cursor update');
@@ -149,7 +149,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
   }
 
   async getSelf(): Promise<CursorUpdate | undefined> {
-    const self = this.space.members.getSelf();
+    const self = await this.space.members.getSelf();
     if (!self) return;
 
     const allCursors = await this.getAll();
@@ -157,7 +157,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
   }
 
   async getOthers(): Promise<Record<string, null | CursorUpdate>> {
-    const self = this.space.members.getSelf();
+    const self = await this.space.members.getSelf();
     if (!self) return {};
 
     const allCursors = await this.getAll();

--- a/src/Locations.test.ts
+++ b/src/Locations.test.ts
@@ -31,20 +31,20 @@ describe('Locations', () => {
 
   describe('set', () => {
     it<SpaceTestContext>('errors if setting location before entering the space', ({ space }) => {
-      expect(() => space.locations.set('location1')).toThrowError();
+      expect(() => space.locations.set('location1')).rejects.toThrowError();
     });
 
     it<SpaceTestContext>('sends a presence update on location set', async ({ space, presence }) => {
       const spy = vi.spyOn(presence, 'update');
       await space.enter();
-      space.locations.set('location1');
+      await space.locations.set('location1');
       expect(spy).toHaveBeenCalledWith(createLocationUpdate({ current: 'location1' }));
     });
 
     it<SpaceTestContext>('fires an event when a location is set', async ({ space }) => {
       const spy = vi.fn();
       space.locations.subscribe('update', spy);
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           data: createLocationUpdate({ current: 'location1' }),
         }),
@@ -56,13 +56,13 @@ describe('Locations', () => {
       const spy = vi.fn();
       space.locations.subscribe('update', spy);
 
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           data: createLocationUpdate({ current: 'location1' }),
         }),
       );
 
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           data: createLocationUpdate({ current: 'location2', previous: 'location1', id: 'newId' }),
         }),
@@ -78,43 +78,43 @@ describe('Locations', () => {
 
   describe('location getters', () => {
     it<SpaceTestContext>('getSelf returns the location only for self', async ({ space }) => {
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           data: createLocationUpdate({ current: 'location1' }),
         }),
       );
-      expect(space.locations.getSelf()).toEqual('location1');
+      expect(space.locations.getSelf()).resolves.toEqual('location1');
     });
 
     it<SpaceTestContext>('getOthers returns the locations only for others', async ({ space }) => {
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', { data: createLocationUpdate({ current: 'location1' }) }),
       );
 
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           connectionId: '2',
           data: createLocationUpdate({ current: 'location2' }),
         }),
       );
 
-      const othersLocations = space.locations.getOthers();
+      const othersLocations = await space.locations.getOthers();
       expect(othersLocations).toEqual({ '2': 'location2' });
     });
 
     it<SpaceTestContext>('getAll returns the locations for self and others', async ({ space }) => {
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', { data: createLocationUpdate({ current: 'location1' }) }),
       );
 
-      space['onPresenceUpdate'](
+      await space['onPresenceUpdate'](
         createPresenceMessage('update', {
           connectionId: '2',
           data: createLocationUpdate({ current: 'location2' }),
         }),
       );
 
-      const allLocations = space.locations.getAll();
+      const allLocations = await space.locations.getAll();
       expect(allLocations).toEqual({ '1': 'location1', '2': 'location2' });
     });
   });

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -104,7 +104,7 @@ describe('Locks (mockClient)', () => {
 
     it<SpaceTestContext>('sets a PENDING request to LOCKED', async ({ space }) => {
       await space.enter();
-      const member = space.members.getSelf()!;
+      const member = (await space.members.getSelf())!;
 
       const emitSpy = vi.spyOn(space.locks, 'emit');
 
@@ -120,7 +120,7 @@ describe('Locks (mockClient)', () => {
           ],
         },
       });
-      space.locks.processPresenceMessage(msg);
+      await space.locks.processPresenceMessage(msg);
 
       const lock = space.locks.getLockRequest(lockID, member.connectionId)!;
       expect(lock.status).toBe('locked');
@@ -183,7 +183,7 @@ describe('Locks (mockClient)', () => {
             ],
           },
         });
-        space.locks.processPresenceMessage(msg);
+        await space.locks.processPresenceMessage(msg);
         const lock = space.locks.get(lockID)!;
         expect(lock.member.connectionId).toBe(otherConnId);
 
@@ -202,11 +202,11 @@ describe('Locks (mockClient)', () => {
             ],
           },
         });
-        space.locks.processPresenceMessage(msg);
-        const selfMember = space.members.getByConnectionId(client.connection.id!)!;
+        await space.locks.processPresenceMessage(msg);
+        const selfMember = (await space.members.getByConnectionId(client.connection.id!))!;
         const selfLock = space.locks.getLockRequest(lockID, selfMember.connectionId)!;
         expect(selfLock.status).toBe(expectedSelfStatus);
-        const otherMember = space.members.getByConnectionId(otherConnId)!;
+        const otherMember = (await space.members.getByConnectionId(otherConnId))!;
         const otherLock = space.locks.getLockRequest(lockID, otherMember.connectionId)!;
         expect(otherLock.status).toBe(expectedOtherStatus);
 
@@ -223,7 +223,7 @@ describe('Locks (mockClient)', () => {
 
     it<SpaceTestContext>('sets a released request to UNLOCKED', async ({ space }) => {
       await space.enter();
-      const member = space.members.getSelf()!;
+      const member = (await space.members.getSelf())!;
 
       let msg = Realtime.PresenceMessage.fromValues({
         connectionId: member.connectionId,
@@ -237,7 +237,7 @@ describe('Locks (mockClient)', () => {
           ],
         },
       });
-      space.locks.processPresenceMessage(msg);
+      await space.locks.processPresenceMessage(msg);
 
       const emitSpy = vi.spyOn(space.locks, 'emit');
 
@@ -245,7 +245,7 @@ describe('Locks (mockClient)', () => {
         connectionId: member.connectionId,
         extras: undefined,
       });
-      space.locks.processPresenceMessage(msg);
+      await space.locks.processPresenceMessage(msg);
 
       const lock = space.locks.getLockRequest(lockID, member.connectionId);
       expect(lock).not.toBeDefined();
@@ -260,7 +260,7 @@ describe('Locks (mockClient)', () => {
 
     it<SpaceTestContext>('removes the identified lock request from presence extras', async ({ space, presence }) => {
       await space.enter();
-      const member = space.members.getSelf()!;
+      const member = (await space.members.getSelf())!;
 
       const lockID = 'test';
       const msg = Realtime.PresenceMessage.fromValues({
@@ -275,7 +275,7 @@ describe('Locks (mockClient)', () => {
           ],
         },
       });
-      space.locks.processPresenceMessage(msg);
+      await space.locks.processPresenceMessage(msg);
       expect(space.locks.get(lockID)).toBeDefined();
 
       const presenceUpdate = vi.spyOn(presence, 'update');

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -53,7 +53,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
   }
 
   async acquire(id: string, opts?: LockOptions): Promise<LockRequest> {
-    const self = this.space.members.getSelf();
+    const self = await this.space.members.getSelf();
     if (!self) {
       throw new Error('Must enter a space before acquiring a lock');
     }
@@ -83,7 +83,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
   }
 
   async release(id: string): Promise<void> {
-    const self = this.space.members.getSelf();
+    const self = await this.space.members.getSelf();
     if (!self) {
       throw new Error('Must enter a space before acquiring a lock');
     }
@@ -127,8 +127,8 @@ export default class Locks extends EventEmitter<LockEventMap> {
     }
   }
 
-  processPresenceMessage(message: Types.PresenceMessage) {
-    const member = this.space.members.getByConnectionId(message.connectionId);
+  async processPresenceMessage(message: Types.PresenceMessage) {
+    const member = await this.space.members.getByConnectionId(message.connectionId);
     if (!member) return;
 
     if (!Array.isArray(message?.extras?.locks)) {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -94,11 +94,11 @@ class Space extends EventEmitter<SpaceEventsMap> {
     };
   }
 
-  private onPresenceUpdate(message: PresenceMember) {
-    this.members.processPresenceMessage(message);
-    this.locations.processPresenceMessage(message);
-    this.locks.processPresenceMessage(message);
-    this.emit('update', { members: this.members.getAll() });
+  private async onPresenceUpdate(message: PresenceMember) {
+    await this.members.processPresenceMessage(message);
+    await this.locations.processPresenceMessage(message);
+    await this.locks.processPresenceMessage(message);
+    this.emit('update', { members: await this.members.getAll() });
   }
 
   async enter(profileData: ProfileData = null): Promise<SpaceMember[]> {
@@ -137,7 +137,7 @@ class Space extends EventEmitter<SpaceEventsMap> {
       | Record<string, unknown>
       | ((update: Record<string, unknown> | null) => Record<string, unknown>),
   ): Promise<void> {
-    const self = this.members.getSelf();
+    const self = await this.members.getSelf();
 
     if (!isObject(profileDataOrUpdateFn) && !isFunction(profileDataOrUpdateFn)) {
       throw new Error('Space.updateProfileData(): Invalid arguments: ' + inspect([profileDataOrUpdateFn]));
@@ -163,8 +163,8 @@ class Space extends EventEmitter<SpaceEventsMap> {
     return this.presenceUpdate(update);
   }
 
-  leave(profileData: ProfileData = null) {
-    const self = this.members.getSelf();
+  async leave(profileData: ProfileData = null) {
+    const self = await this.members.getSelf();
 
     if (!self) {
       throw new Error('You must enter a space before attempting to leave it');
@@ -182,11 +182,12 @@ class Space extends EventEmitter<SpaceEventsMap> {
       },
     };
 
-    return this.presenceLeave(update);
+    await this.presenceLeave(update);
   }
 
-  getState(): { members: SpaceMember[] } {
-    return { members: this.members.getAll() };
+  async getState(): Promise<{ members: SpaceMember[] }> {
+    const members = await this.members.getAll();
+    return { members };
   }
 
   subscribe<K extends EventKey<SpaceEventsMap>>(

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -58,8 +58,12 @@ const createPresenceMessage = <T extends keyof MessageMap>(type: T, override?: P
   }
 };
 
-const createPresenceEvent = <T extends keyof MessageMap>(space: Space, type: T, override?: Partial<MessageMap[T]>) => {
-  space['onPresenceUpdate'](createPresenceMessage(type, override));
+const createPresenceEvent = async <T extends keyof MessageMap>(
+  space: Space,
+  type: T,
+  override?: Partial<MessageMap[T]>,
+) => {
+  await space['onPresenceUpdate'](createPresenceMessage(type, override));
 };
 
 const createLocationUpdate = (update?: Partial<PresenceMember['data']['locationUpdate']>): PresenceMember['data'] => {


### PR DESCRIPTION
In preparation for the `Members` class using the async `presence.get()` rather than maintaining a separate `members` array (see https://ably.atlassian.net/browse/MMB-182). There is no functional change here, just mainly awaiting promises for whatever is now async.