### PR TITLE
members: Drop the members array in favour of presence.get()

### DIFF
--- a/src/Locations.test.ts
+++ b/src/Locations.test.ts
@@ -3,12 +3,18 @@ import { Realtime, Types } from 'ably/promises';
 
 import Space from './Space.js';
 
-import { createPresenceMessage, createLocationUpdate, createSpaceMember } from './utilities/test/fakes.js';
+import {
+  createPresenceEvent,
+  createPresenceMessage,
+  createLocationUpdate,
+  createSpaceMember,
+} from './utilities/test/fakes.js';
 
 interface SpaceTestContext {
   client: Types.RealtimePromise;
   space: Space;
   presence: Types.RealtimePresencePromise;
+  presenceMap: Map<string, Types.PresenceMessage>;
 }
 
 vi.mock('ably/promises');
@@ -18,19 +24,26 @@ describe('Locations', () => {
   beforeEach<SpaceTestContext>((context) => {
     const client = new Realtime({});
     const presence = client.channels.get('').presence;
+    const presenceMap = new Map();
 
-    vi.spyOn(presence, 'get').mockImplementationOnce(async () => [
-      createPresenceMessage('enter', { clientId: 'MOCK_CLIENT_ID' }),
-      createPresenceMessage('update', { clientId: '2', connectionId: '2' }),
-    ]);
+    presenceMap.set('1', createPresenceMessage('enter', { clientId: 'MOCK_CLIENT_ID' }));
+    presenceMap.set('2', createPresenceMessage('update', { clientId: '2', connectionId: '2' }));
+
+    vi.spyOn(presence, 'get').mockImplementation(async () => {
+      return Array.from(presenceMap.values());
+    });
 
     context.client = client;
     context.space = new Space('test', client);
     context.presence = presence;
+    context.presenceMap = presenceMap;
   });
 
   describe('set', () => {
-    it<SpaceTestContext>('errors if setting location before entering the space', ({ space }) => {
+    it<SpaceTestContext>('errors if setting location before entering the space', ({ space, presence }) => {
+      // override presence.get() so the current member is not in presence
+      vi.spyOn(presence, 'get').mockImplementation(async () => []);
+
       expect(() => space.locations.set('location1')).rejects.toThrowError();
     });
 
@@ -41,32 +54,26 @@ describe('Locations', () => {
       expect(spy).toHaveBeenCalledWith(createLocationUpdate({ current: 'location1' }));
     });
 
-    it<SpaceTestContext>('fires an event when a location is set', async ({ space }) => {
+    it<SpaceTestContext>('fires an event when a location is set', async ({ space, presenceMap }) => {
       const spy = vi.fn();
       space.locations.subscribe('update', spy);
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          data: createLocationUpdate({ current: 'location1' }),
-        }),
-      );
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location1' }),
+      });
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it<SpaceTestContext>('correctly sets previousLocation', async ({ space }) => {
+    it<SpaceTestContext>('correctly sets previousLocation', async ({ space, presenceMap }) => {
       const spy = vi.fn();
       space.locations.subscribe('update', spy);
 
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          data: createLocationUpdate({ current: 'location1' }),
-        }),
-      );
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location1' }),
+      });
 
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          data: createLocationUpdate({ current: 'location2', previous: 'location1', id: 'newId' }),
-        }),
-      );
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location2', previous: 'location1', id: 'newId' }),
+      });
 
       expect(spy).toHaveBeenLastCalledWith({
         member: createSpaceMember({ location: 'location2' }),
@@ -77,42 +84,36 @@ describe('Locations', () => {
   });
 
   describe('location getters', () => {
-    it<SpaceTestContext>('getSelf returns the location only for self', async ({ space }) => {
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          data: createLocationUpdate({ current: 'location1' }),
-        }),
-      );
+    it<SpaceTestContext>('getSelf returns the location only for self', async ({ space, presenceMap }) => {
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location1' }),
+      });
       expect(space.locations.getSelf()).resolves.toEqual('location1');
     });
 
-    it<SpaceTestContext>('getOthers returns the locations only for others', async ({ space }) => {
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', { data: createLocationUpdate({ current: 'location1' }) }),
-      );
+    it<SpaceTestContext>('getOthers returns the locations only for others', async ({ space, presenceMap }) => {
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location1' }),
+      });
 
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          connectionId: '2',
-          data: createLocationUpdate({ current: 'location2' }),
-        }),
-      );
+      await createPresenceEvent(space, presenceMap, 'update', {
+        connectionId: '2',
+        data: createLocationUpdate({ current: 'location2' }),
+      });
 
       const othersLocations = await space.locations.getOthers();
       expect(othersLocations).toEqual({ '2': 'location2' });
     });
 
-    it<SpaceTestContext>('getAll returns the locations for self and others', async ({ space }) => {
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', { data: createLocationUpdate({ current: 'location1' }) }),
-      );
+    it<SpaceTestContext>('getAll returns the locations for self and others', async ({ space, presenceMap }) => {
+      await createPresenceEvent(space, presenceMap, 'update', {
+        data: createLocationUpdate({ current: 'location1' }),
+      });
 
-      await space['onPresenceUpdate'](
-        createPresenceMessage('update', {
-          connectionId: '2',
-          data: createLocationUpdate({ current: 'location2' }),
-        }),
-      );
+      await createPresenceEvent(space, presenceMap, 'update', {
+        connectionId: '2',
+        data: createLocationUpdate({ current: 'location2' }),
+      });
 
       const allLocations = await space.locations.getAll();
       expect(allLocations).toEqual({ '1': 'location1', '2': 'location2' });

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -111,10 +111,10 @@ class Space extends EventEmitter<SpaceEventsMap> {
 
       (presence as PresenceWithSubscriptions).subscriptions.once('enter', async () => {
         const presenceMessages = await presence.get();
-        const members = this.members.mapPresenceMembersToSpaceMembers(presenceMessages);
 
         presenceMessages.forEach((msg) => this.locks.processPresenceMessage(msg));
 
+        const members = await this.members.getAll();
         resolve(members);
       });
 

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -60,10 +60,17 @@ const createPresenceMessage = <T extends keyof MessageMap>(type: T, override?: P
 
 const createPresenceEvent = async <T extends keyof MessageMap>(
   space: Space,
+  presenceMap: Map<string, Types.PresenceMessage>,
   type: T,
   override?: Partial<MessageMap[T]>,
 ) => {
-  await space['onPresenceUpdate'](createPresenceMessage(type, override));
+  const member = createPresenceMessage(type, override);
+  if (type == 'leave') {
+    presenceMap.delete(member.connectionId);
+  } else {
+    presenceMap.set(member.connectionId, member);
+  }
+  await space['onPresenceUpdate'](member);
 };
 
 const createLocationUpdate = (update?: Partial<PresenceMember['data']['locationUpdate']>): PresenceMember['data'] => {


### PR DESCRIPTION
Since maintaining a shadow copy of presence state is an anti-pattern, see https://ably.atlassian.net/browse/MMB-182.

This mainly updates the tests so that emitting a presence update message is accompanied by that update being reflected in subsequent calls to `presence.get()`.

[MMB-182]

[MMB-182]: https://ably.atlassian.net/browse/MMB-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ