### PR TITLE
space: Ensure lock state is maintained in presence data

### DIFF
--- a/src/Locations.test.ts
+++ b/src/Locations.test.ts
@@ -81,6 +81,18 @@ describe('Locations', () => {
         previousLocation: 'location1',
       });
     });
+
+    it<SpaceTestContext>('maintains lock state in presence', async ({ space, presence, presenceMap }) => {
+      presenceMap.set('1', createPresenceMessage('enter'));
+
+      const lockID = 'test';
+      const lockReq = await space.locks.acquire(lockID);
+
+      const spy = vi.spyOn(presence, 'update');
+      await space.locations.set('location');
+      const extras = { locks: [lockReq] };
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ extras }));
+    });
   });
 
   describe('location getters', () => {

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -18,7 +18,10 @@ type LocationsEventMap = {
 export default class Locations extends EventEmitter<LocationsEventMap> {
   private lastLocationUpdate: Record<string, PresenceMember['data']['locationUpdate']['id']> = {};
 
-  constructor(private space: Space, private presenceUpdate: (update: PresenceMember['data']) => Promise<void>) {
+  constructor(
+    private space: Space,
+    private presenceUpdate: (update: PresenceMember['data'], extras?: PresenceMember['extras']) => Promise<void>,
+  ) {
     super();
   }
 
@@ -69,7 +72,8 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
       },
     };
 
-    await this.presenceUpdate(update);
+    const extras = this.space.locks.getLockExtras(self.connectionId);
+    await this.presenceUpdate(update, extras);
   }
 
   subscribe<K extends EventKey<LocationsEventMap>>(

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -239,12 +239,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
         previous: null,
       },
     };
-    let extras;
-    const locks = this.getLockRequests(member.connectionId);
-    if (locks.length > 0) {
-      extras = { locks };
-    }
-    return this.presenceUpdate(update, extras);
+    return this.presenceUpdate(update, this.getLockExtras(member.connectionId));
   }
 
   getLock(id: string, connectionId: string): Lock | undefined {
@@ -283,5 +278,11 @@ export default class Locks extends EventEmitter<LockEventMap> {
       }
     }
     return requests;
+  }
+
+  getLockExtras(connectionId: string): PresenceMember['extras'] {
+    const locks = this.getLockRequests(connectionId);
+    if (locks.length === 0) return;
+    return { locks };
   }
 }

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -158,6 +158,18 @@ describe('Space', () => {
         expect(updateSpy).toHaveBeenNthCalledWith(1, createProfileUpdate({ current: { name: 'Betty' } }));
       });
     });
+
+    it<SpaceTestContext>('maintains lock state in presence', async ({ space, presence, presenceMap }) => {
+      presenceMap.set('1', createPresenceMessage('enter'));
+
+      const lockID = 'test';
+      const lockReq = await space.locks.acquire(lockID);
+
+      const updateSpy = vi.spyOn(presence, 'update');
+      await space.updateProfileData({ name: 'Betty' });
+      const extras = { locks: [lockReq] };
+      expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ extras }));
+    });
   });
 
   describe('leave', () => {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -160,7 +160,8 @@ class Space extends EventEmitter<SpaceEventsMap> {
       return;
     }
 
-    return this.presenceUpdate(update);
+    const extras = this.locks.getLockExtras(self.connectionId);
+    return this.presenceUpdate(update, extras);
   }
 
   async leave(profileData: ProfileData = null) {


### PR DESCRIPTION
Prior to this change, updating profile data or setting location would remove all lock state from presence since `extras` would be set to `null`, which would wrongly release all locks held my the current member.