### PR TITLE
Change 'cursorsUpdate' event to 'update'

### DIFF
--- a/demo/src/components/Cursors.tsx
+++ b/demo/src/components/Cursors.tsx
@@ -60,7 +60,7 @@ export const Cursors = () => {
   useEffect(() => {
     if (!space || !members) return;
 
-    space.cursors.subscribe('cursorsUpdate', (cursorUpdate) => {
+    space.cursors.subscribe('update', (cursorUpdate) => {
       const { connectionId } = cursorUpdate;
       const member = find<Member>(members, { connectionId });
 
@@ -89,7 +89,7 @@ export const Cursors = () => {
     });
 
     return () => {
-      space.cursors.unsubscribe('cursorsUpdate');
+      space.cursors.unsubscribe('update');
     };
   }, [space, members]);
 

--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -38,7 +38,7 @@ describe('Cursors', () => {
     context.space = new Space('test', client);
     context.cursors = context.space.cursors;
     // This will set the channel
-    context.cursors.subscribe('cursorsUpdate', () => {});
+    context.cursors.subscribe('update', () => {});
     context.channel = context.cursors['channel'] as Types.RealtimeChannelPromise;
     context.batching = context.space.cursors['cursorBatching'];
     context.dispensing = context.space.cursors['cursorDispensing'];

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -16,7 +16,7 @@ import type { CursorsOptions, CursorUpdate } from './types.js';
 import type { RealtimeMessage } from './utilities/types.js';
 
 type CursorsEventMap = {
-  cursorsUpdate: CursorUpdate;
+  update: CursorUpdate;
 };
 
 export default class Cursors extends EventEmitter<CursorsEventMap> {
@@ -34,7 +34,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     this.cursorHistory = new CursorHistory();
     this.cursorBatching = new CursorBatching(this.options.outboundBatchInterval);
 
-    const emitCursorUpdate = (update: CursorUpdate): void => this.emit('cursorsUpdate', update);
+    const emitCursorUpdate = (update: CursorUpdate): void => this.emit('update', update);
     this.cursorDispensing = new CursorDispensing(emitCursorUpdate);
   }
 


### PR DESCRIPTION
The API states that a namespace should use `update` for the event name rather than `cursorUpdate`.