### PR TITLE
[MMB-127] Small changes to prepare for repo migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily" # weekdays (Monday to Friday)
+    labels: [ ] # prevent the default `dependencies` label from being added to pull requests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
   </a>
 </p>
 
-The [Ably](https://ably.com) Collaborative Spaces SDK enables you to implement realtime collaborative features in your applications. 
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/docs)._
+
+---
+
+The [Ably](https://ably.com) Collaborative Spaces SDK enables you to implement realtime collaborative features in your applications.
 
 ![Example collaboration GIF](/docs/images/collab.gif)
 


### PR DESCRIPTION
A couple of small changes to help prepare for the eventual migration from `ably-labs` organization to `ably`.

1. Add Dependabot configuration, since we should ensure we're keeping dependencies up to date where possible
2. Add the header that is used across all our SDKs