### PR TITLE
fix: rename `types.d.ts` to `types.ts`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Types } from 'ably';
+import { LockAttributes } from './Locks';
 
 export interface CursorsOptions {
   outboundBatchInterval: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Types } from 'ably';
-import { LockAttributes } from './Locks.js';
+import type { LockAttributes } from './Locks.js';
 
 export interface CursorsOptions {
   outboundBatchInterval: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Types } from 'ably';
-import { LockAttributes } from './Locks';
+import { LockAttributes } from './Locks.js';
 
 export interface CursorsOptions {
   outboundBatchInterval: number;

--- a/src/utilities/test/fakes.ts
+++ b/src/utilities/test/fakes.ts
@@ -3,7 +3,7 @@ import { Types } from 'ably';
 import Space from '../../Space.js';
 
 import type { SpaceMember } from '../../types.js';
-import type { PresenceMember } from '../../utilities/types.js';
+import type { PresenceMember } from '../types.js';
 
 // import { nanoidId } from '../../../__mocks__/nanoid/index.js';
 const nanoidId = 'NanoidID';

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,7 +1,7 @@
-import { Types } from 'ably';
+import type { Types } from 'ably';
 
-import { EventKey, EventListener, EventMap } from './EventEmitter.js';
-import { ProfileData, LockRequest } from '../types.js';
+import type { EventKey, EventListener, EventMap } from './EventEmitter.js';
+import type { ProfileData, LockRequest } from '../types.js';
 
 export type PresenceMember = {
   data: {
@@ -28,12 +28,12 @@ export interface Provider<ProviderEventMap extends EventMap> {
   subscribe<K extends EventKey<ProviderEventMap>>(
     listenerOrEvents?: K | K[] | EventListener<ProviderEventMap[K]>,
     listener?: EventListener<ProviderEventMap[K]>,
-  );
+  ): void;
 
   unsubscribe<K extends EventKey<ProviderEventMap>>(
     listenerOrEvents?: K | K[] | EventListener<ProviderEventMap[K]>,
     listener?: EventListener<ProviderEventMap[K]>,
-  );
+  ): void;
 }
 
 export type RealtimeMessage = Omit<Types.Message, 'connectionId'> & {


### PR DESCRIPTION
`.d.ts` files designed to be backed by `.js` files, using them just for type declaration can lead to type errors after the compilation