### PR TITLE
Add legacy CDN upload

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -47,4 +47,30 @@ jobs:
           npm run build
       - run: |
           aws s3 cp ./dist/iife/index.bundle.js s3://${{ github.event.inputs.bucket }}/spaces/${{ github.event.inputs.version }}/iife/index.bundle.js
-
+  publish_legacy:
+    if: ${{ github.event.inputs.bucket == 'prod-cdn.ably.com' }} # Only run for the prod build
+    runs-on: ubuntu-latest
+    # These permissions are necessary to run the configure-aws-credentials action
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_PRODUCTION }}:role/github-actions-sdk
+          aws-region: us-east-1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - name: Install dependencies and build
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm run build
+      - run: |
+          aws s3 cp ./dist/iife/index.bundle.js s3://cdn.ably.io/spaces/${{ github.event.inputs.version }}/iife/index.bundle.js


### PR DESCRIPTION
I mistakenly thought cdn.ably.com was using the new bucket, but it's actually using the old bucket. Until we are migrated we will need to also upload files to the old bucket.

Required PR: https://github.com/ably/infrastructure/pull/6292