### PR TITLE
Prefer null over undefined consistently

### DIFF
--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -455,7 +455,7 @@ describe('Cursors', () => {
       vi.spyOn(space.cursors, 'getAll').mockImplementation(async () => ({}));
 
       const self = await space.cursors.getSelf();
-      expect(self).toBeUndefined();
+      expect(self).toBeNull();
     });
 
     it<CursorsTestContext>('returns the cursor update for self', async ({
@@ -472,7 +472,7 @@ describe('Cursors', () => {
 
     it<CursorsTestContext>('returns an empty object if self is not present in cursors', async ({ space }) => {
       vi.spyOn(space.cursors, 'getAll').mockResolvedValue({});
-      vi.spyOn(space.members, 'getSelf').mockResolvedValue(undefined);
+      vi.spyOn(space.members, 'getSelf').mockResolvedValue(null);
 
       const others = await space.cursors.getOthers();
       expect(others).toEqual({});

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -149,12 +149,12 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     }
   }
 
-  async getSelf(): Promise<CursorUpdate | undefined> {
+  async getSelf(): Promise<CursorUpdate | null> {
     const self = await this.space.members.getSelf();
-    if (!self) return;
+    if (!self) return null;
 
     const allCursors = await this.getAll();
-    return allCursors[self.connectionId] as CursorUpdate;
+    return allCursors[self.connectionId];
   }
 
   async getOthers(): Promise<Record<string, null | CursorUpdate>> {
@@ -167,7 +167,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     return allCursorsFiltered;
   }
 
-  async getAll() {
+  async getAll(): Promise<Record<string, null | CursorUpdate>> {
     const channel = this.getChannel();
     return await this.cursorHistory.getLastCursorUpdate(channel, this.options.paginationLimit);
   }

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -50,8 +50,8 @@ class Members extends EventEmitter<MemberEventsMap> {
     }
   }
 
-  async getSelf(): Promise<SpaceMember | undefined> {
-    return this.space.connectionId ? await this.getByConnectionId(this.space.connectionId) : undefined;
+  async getSelf(): Promise<SpaceMember | null> {
+    return this.space.connectionId ? await this.getByConnectionId(this.space.connectionId) : null;
   }
 
   async getAll(): Promise<SpaceMember[]> {
@@ -99,9 +99,9 @@ class Members extends EventEmitter<MemberEventsMap> {
     }
   }
 
-  async getByConnectionId(connectionId: string): Promise<SpaceMember | undefined> {
+  async getByConnectionId(connectionId: string): Promise<SpaceMember | null> {
     const members = await this.getAll();
-    return members.find((m) => m.connectionId === connectionId);
+    return members.find((m) => m.connectionId === connectionId) ?? null;
   }
 
   createMember(message: PresenceMember): SpaceMember {

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -77,7 +77,7 @@ describe('Space', () => {
       expect(member).toEqual(createSpaceMember());
 
       const noMember = await space.members.getByConnectionId('nonExistentConnectionId');
-      expect(noMember).toBe(undefined);
+      expect(noMember).toBeNull();
     });
 
     it<SpaceTestContext>('initialises locks', async ({ presenceMap, space }) => {


### PR DESCRIPTION
This makes `get*` methods consistent, always returning `null` instead `undefined` when no values are found.