### PR TITLE
Fix getAll no returing position or data values

### DIFF
--- a/src/CursorBatching.ts
+++ b/src/CursorBatching.ts
@@ -4,7 +4,7 @@ import { CURSOR_UPDATE } from './CursorConstants.js';
 import type { CursorUpdate } from './types.js';
 import type { CursorsOptions } from './types.js';
 
-type OutgoingBuffer = { cursor: Pick<CursorUpdate, 'position' | 'data'>; offset: number };
+export type OutgoingBuffer = { cursor: Pick<CursorUpdate, 'position' | 'data'>; offset: number };
 
 export default class CursorBatching {
   outgoingBuffer: OutgoingBuffer[] = [];

--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -387,13 +387,16 @@ describe('Cursors', () => {
       const client1Message = {
         connectionId: 'connectionId1',
         clientId: 'clientId1',
-        data: [{ position: { x: 1, y: 1 } }, { position: { x: 2, y: 3 }, data: { color: 'blue' } }],
+        data: [
+          { cursor: { position: { x: 1, y: 1 } } },
+          { cursor: { position: { x: 2, y: 3 }, data: { color: 'blue' } } },
+        ],
       };
 
       const client2Message = {
         connectionId: 'connectionId2',
         clientId: 'clientId2',
-        data: [{ position: { x: 25, y: 44 } }],
+        data: [{ cursor: { position: { x: 25, y: 44 } } }],
       };
 
       vi.spyOn(channel.presence, 'get').mockImplementation(async () => [


### PR DESCRIPTION
This broke when we added offsets to the OutgoingBuffer in cursors. Unfortuntely, the relevant tests need to mock the whole presence message and did not catch this change.

When we implement integration tests, this should be a prime candidate for a golden path test as it needs to go via multiple separate modules as well as Ably.